### PR TITLE
Update config_flow.py

### DIFF
--- a/custom_components/nilan/config_flow.py
+++ b/custom_components/nilan/config_flow.py
@@ -9,7 +9,7 @@ import logging
 
 from homeassistant import config_entries
 
-from pymodbus.client.sync import ModbusTcpClient, ModbusSerialClient
+from pymodbus.client import ModbusTcpClient, ModbusSerialClient
 from pymodbus.exceptions import ModbusException
 
 from .device import CTS602_DEVICE_TYPES


### PR DESCRIPTION
Home assistant 2023.2.0 gives error:
Error importing platform config_flow from integration nilan to set up nilan configuration entry: No module named 'pymodbus.client.sync' Removing 'sync' from module name fix it.