### PR TITLE
Workaround 2024.4 setup issue

### DIFF
--- a/custom_components/nilan/config_flow.py
+++ b/custom_components/nilan/config_flow.py
@@ -6,6 +6,8 @@ from typing import Any, Optional
 
 from pymodbus.client import AsyncModbusSerialClient, AsyncModbusTcpClient
 from pymodbus.exceptions import ModbusException
+from homeassistant.components.modbus import ModbusHub
+PARALLEL_UPDATES = 1
 import voluptuous as vol
 
 from homeassistant import config_entries

--- a/custom_components/nilan/config_flow.py
+++ b/custom_components/nilan/config_flow.py
@@ -6,8 +6,6 @@ from typing import Any, Optional
 
 from pymodbus.client import AsyncModbusSerialClient, AsyncModbusTcpClient
 from pymodbus.exceptions import ModbusException
-from homeassistant.components.modbus import ModbusHub
-PARALLEL_UPDATES = 1
 import voluptuous as vol
 
 from homeassistant import config_entries

--- a/custom_components/nilan/device.py
+++ b/custom_components/nilan/device.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 
 import datetime
 import logging
+import asyncio
 
 from homeassistant.components.modbus import modbus
 from homeassistant.core import HomeAssistant
@@ -57,22 +58,23 @@ class Device:
         _LOGGER.debug("Setup has started")
         hw_type = None
         success = await self._modbus.async_setup()
+        await asyncio.sleep(10)
         if success:
             _LOGGER.debug("Modbus has been setup")
             hw_type = await self.get_machine_type()
             _LOGGER.debug("Device Type = %s", str(hw_type))
             if hw_type is None:
-                self._modbus.async_close()
+                await self._modbus.async_close()
                 raise ValueError("hw_type returned None")
             bus_version = await self.get_bus_version()
             _LOGGER.debug("Bus version = %s", str(bus_version))
             if bus_version is None:
-                self._modbus.async_close()
+                await self._modbus.async_close()
                 raise ValueError("bus_version returned None")
             if hw_type == 44:
                 self._air_geo_type = await self.check_air_geo()
         else:
-            self._modbus.async_close()
+            await self._modbus.async_close()
             raise ValueError("Modbus setup was unsuccessful")
         if hw_type in CTS602_DEVICE_TYPES:
             self._device_sw_ver = await self.get_controller_software_version()
@@ -121,7 +123,7 @@ class Device:
                                 continue
                         self._attributes[entity] = value["entity_type"]
         else:
-            self._modbus.async_close()
+            await self._modbus.async_close()
             raise ValueError("HW type not supported")
         if "get_controller_hardware_version" in self._attributes:
             self._device_hw_ver = await self.get_controller_hardware_version()


### PR DESCRIPTION
After HA 2024.4 the Modbus async_setup call does not longer wait for the modbus connection.

Thus you will receive the errors:
```
2024-04-04 11:56:17.249 ERROR (MainThread) [homeassistant.components.modbus.modbus] Pymodbus: Nilan: Error: device: 30 address: 1000 -> Modbus Error: [Connection] Not connected[AsyncModbusSerialClient /dev/ttyUSB2:0]
2024-04-04 11:56:17.280 ERROR (MainThread) [custom_components.nilan.device] Could not read get_machine_type
2024-04-04 11:56:17.280 DEBUG (MainThread) [custom_components.nilan.device] Device Type = None
2024-04-04 11:56:17.283 WARNING (MainThread) [homeassistant.components.modbus.modbus] modbus Nilan communication closed
```

As well as the follwing errors because the connection is not closed properly:
```
2024-04-03 23:10:30.901 WARNING (MainThread) [py.warnings] /config/custom_components/nilan/device.py:65: RuntimeWarning: coroutine 'ModbusHub.async_close' was never awaited
  self._modbus.async_close()

2024-04-03 23:32:56.379 WARNING (MainThread) [pymodbus.logging] Failed to connect [Errno 11] Could not exclusively lock port /dev/ttyUSB2: [Errno 11] Resource temporarily unavailable
2024-04-03 23:34:16.553 ERROR (MainThread) [homeassistant.components.modbus.modbus] Pymodbus: Nilan: Error: device: 30 address: 1000 -> Modbus Error: [Connection] Not connected[AsyncModbusSerialClient /dev/ttyUSB2:0]
```

This may have been caused by recent HA modbus changes to switch to async Clients:
https://github.com/home-assistant/core/commit/7cba34b2e6b53621e6188ff2b473a3553e72bdcd?diff=split&w=0


## Note:
* The workaround is far from perfect (callback on connect would be better or device setup is stored in config_flow) but a better solution needs to be analyzed/tested first