### PR TITLE
device_map.py including VP 18comp

### DIFF
--- a/custom_components/nilan/device_map.py
+++ b/custom_components/nilan/device_map.py
@@ -4,6 +4,7 @@ CTS602_DEVICE_TYPES = {
     2: "Comfort light",
     4: "VPL 15c",
     10: "CompactS",
+    11: "VP 18comp",
     12: "VP18cCom",
     13: "COMFORT",
     19: "VP 18c",
@@ -68,6 +69,7 @@ CTS602_ENTITY_MAP = {
         "supported_devices": (
             4,
             10,
+            11,
             12,
             19,
             20,
@@ -119,6 +121,7 @@ CTS602_ENTITY_MAP = {
         "supported_devices": (
             4,
             10,
+            11,
             12,
             19,
             20,
@@ -138,6 +141,7 @@ CTS602_ENTITY_MAP = {
         "supported_devices": (
             4,
             10,
+            11,
             12,
             19,
             20,
@@ -158,6 +162,7 @@ CTS602_ENTITY_MAP = {
             2,
             4,
             10,
+            11,
             12,
             13,
             19,
@@ -194,6 +199,7 @@ CTS602_ENTITY_MAP = {
         "supported_devices": (
             4,
             10,
+            11,
             12,
             19,
             20,
@@ -212,6 +218,7 @@ CTS602_ENTITY_MAP = {
         "min_hps_bus_version": 1,
         "supported_devices": (
             10,
+            11,
             12,
             19,
             20,
@@ -226,7 +233,7 @@ CTS602_ENTITY_MAP = {
         "min_hps_bus_version": 1,
         "supported_devices": (
             10,
-            12,
+            11,
             19,
             20,
             21,
@@ -313,6 +320,7 @@ CTS602_ENTITY_MAP = {
             2,
             4,
             10,
+            11,
             12,
             13,
             19,
@@ -370,6 +378,7 @@ CTS602_ENTITY_MAP = {
             2,
             4,
             10,
+            11,
             12,
             13,
             19,
@@ -399,6 +408,7 @@ CTS602_ENTITY_MAP = {
         "min_hps_bus_version": 1,
         "supported_devices": (
             10,
+            11,
             12,
             19,
             20,
@@ -536,6 +546,7 @@ CTS602_ENTITY_MAP = {
         "supported_devices": (
             4,
             10,
+            11,
             12,
             19,
             20,
@@ -554,6 +565,7 @@ CTS602_ENTITY_MAP = {
         "min_hps_bus_version": 1,
         "supported_devices": (
             10,
+            11,
             12,
             19,
             20,
@@ -610,6 +622,7 @@ CTS602_ENTITY_MAP = {
         "supported_devices": (
             4,
             10,
+            11,
             12,
             19,
             20,
@@ -636,6 +649,7 @@ CTS602_ENTITY_MAP = {
             2,
             4,
             10,
+            11,
             12,
             13,
             19,
@@ -698,6 +712,7 @@ CTS602_ENTITY_MAP = {
         "supported_devices": (
             4,
             10,
+            11,
             19,
             20,
             21,
@@ -712,6 +727,7 @@ CTS602_ENTITY_MAP = {
         "supported_devices": (
             4,
             10,
+            11,
             12,
             19,
             21,
@@ -735,6 +751,7 @@ CTS602_ENTITY_MAP = {
         "supported_devices": (
             4,
             10,
+            11,
             12,
             19,
             21,
@@ -753,6 +770,7 @@ CTS602_ENTITY_MAP = {
             2,
             4,
             10,
+            11,
             12,
             13,
             19,
@@ -774,6 +792,7 @@ CTS602_ENTITY_MAP = {
             2,
             4,
             10,
+            11,
             12,
             13,
             19,
@@ -836,6 +855,7 @@ CTS602_ENTITY_MAP = {
         "supported_devices": (
             4,
             10,
+            11,
             19,
             20,
             21,
@@ -853,6 +873,7 @@ CTS602_ENTITY_MAP = {
         "supported_devices": (
             4,
             10,
+            11,
             19,
             20,
             21,
@@ -868,6 +889,7 @@ CTS602_ENTITY_MAP = {
         "supported_devices": (
             4,
             10,
+            11,
             19,
             20,
             21,
@@ -887,6 +909,7 @@ CTS602_ENTITY_MAP = {
         "supported_devices": (
             4,
             10,
+            11,
             12,
             19,
             20,
@@ -910,6 +933,7 @@ CTS602_ENTITY_MAP = {
         "supported_devices": (
             4,
             10,
+            11,
             19,
             20,
             21,
@@ -927,6 +951,7 @@ CTS602_ENTITY_MAP = {
         "min_hps_bus_version": 1,
         "supported_devices": (
             10,
+            11,
             12,
             19,
             20,
@@ -955,6 +980,7 @@ CTS602_ENTITY_MAP = {
         "min_hps_bus_version": 1,
         "supported_devices": (
             10,
+            11,
             19,
             20,
             21,
@@ -967,6 +993,7 @@ CTS602_ENTITY_MAP = {
         "min_hps_bus_version": 1,
         "supported_devices": (
             10,
+            11,
             12,
             19,
             20,
@@ -981,6 +1008,7 @@ CTS602_ENTITY_MAP = {
         "min_hps_bus_version": 1,
         "supported_devices": (
             10,
+            11,
             19,
             20,
             21,
@@ -995,6 +1023,7 @@ CTS602_ENTITY_MAP = {
         "supported_devices": (
             4,
             10,
+            11,
             19,
             20,
             21,
@@ -1200,6 +1229,7 @@ CTS602_ENTITY_MAP = {
             2,
             4,
             10,
+            11,
             12,
             13,
             19,
@@ -1221,6 +1251,7 @@ CTS602_ENTITY_MAP = {
             2,
             4,
             10,
+            11,
             12,
             13,
             19,
@@ -1242,6 +1273,7 @@ CTS602_ENTITY_MAP = {
             2,
             4,
             10,
+            11,
             12,
             13,
             19,
@@ -1280,6 +1312,7 @@ CTS602_ENTITY_MAP = {
             2,
             4,
             10,
+            11,
             12,
             13,
             19,
@@ -1311,6 +1344,7 @@ CTS602_ENTITY_MAP = {
             2,
             4,
             10,
+            11,
             12,
             13,
             19,
@@ -1351,6 +1385,7 @@ CTS602_ENTITY_MAP = {
         "supported_devices": (
             4,
             10,
+            11,
             19,
             20,
             21,
@@ -1365,6 +1400,7 @@ CTS602_ENTITY_MAP = {
         "supported_devices": (
             4,
             10,
+            11,
             19,
             20,
             21,
@@ -1391,6 +1427,7 @@ CTS602_ENTITY_MAP = {
         "supported_devices": (
             4,
             10,
+            11,
             19,
             20,
             21,
@@ -1409,6 +1446,7 @@ CTS602_ENTITY_MAP = {
         "supported_devices": (
             4,
             10,
+            11,
             19,
             20,
             21,
@@ -1447,6 +1485,7 @@ CTS602_ENTITY_MAP = {
         "supported_devices": (
             4,
             10,
+            11,
             19,
             20,
             21,
@@ -1463,6 +1502,7 @@ CTS602_ENTITY_MAP = {
             2,
             4,
             10,
+            11,
             12,
             13,
             19,
@@ -1484,6 +1524,7 @@ CTS602_ENTITY_MAP = {
             2,
             4,
             10,
+            11,
             12,
             13,
             19,
@@ -1505,6 +1546,7 @@ CTS602_ENTITY_MAP = {
             2,
             4,
             10,
+            11,
             12,
             13,
             19,
@@ -1526,6 +1568,7 @@ CTS602_ENTITY_MAP = {
             2,
             4,
             10,
+            11,
             12,
             13,
             19,


### PR DESCRIPTION
Device 11: “VP 18comp” has been implemented. The individual functions were set analogously to Device 19: “VP 18c” since it should be almost the same device.