### PR TITLE
Fix modbus connection

### DIFF
--- a/custom_components/nilan/device.py
+++ b/custom_components/nilan/device.py
@@ -60,6 +60,7 @@ class Device:
         success = await self._modbus.async_setup()
 
         if success:
+            await self._modbus.event_connected.wait()
             _LOGGER.debug("Modbus has been setup")
         else:
             await self._modbus.async_close()

--- a/custom_components/nilan/manifest.json
+++ b/custom_components/nilan/manifest.json
@@ -7,6 +7,6 @@
   "documentation": "https://github.com/veista/nilan",
   "iot_class": "local_polling",
   "issue_tracker": "https://github.com/veista/nilan/issues",
-  "requirements": ["pymodbus==3.9.2"],
+  "requirements": ["pymodbus>=3.11.1,<3.12"],
   "version": "1.2.21"
 }


### PR DESCRIPTION
-  Update pymodbus dependency
    
    This is stricter than the one proposed in #183 as pymodbus doesn't adhere to semver as they document here https://pymodbus.readthedocs.io/en/latest/.

-  Await for ModbusHub event_connected
    
    Once the setup has been completed await for ModbusHub event_connected to ensure first connection has been made before continuing.
    
    home-assistant/core@53ca36939556241b2bbb23ef2cfa6a1889c3050c changed the logic how connection should be handled.
