### PR TITLE
Add CTS400 / ES1077 board support (refs #165)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,29 @@
+# Byte-compiled / optimized / DLL files
+__pycache__/
+*.py[cod]
+*$py.class
+
+# Distribution / packaging
+build/
+dist/
+*.egg-info/
+
+# Test / coverage / type-check caches
+.pytest_cache/
+.mypy_cache/
+.ruff_cache/
+.coverage
+.coverage.*
+htmlcov/
+
+# Virtual environments
+.venv/
+venv/
+env/
+
+# Editor / OS cruft
+.vscode/
+.idea/
+*.swp
+.DS_Store
+Thumbs.db

--- a/README.md
+++ b/README.md
@@ -29,35 +29,16 @@ If you have CTS700 or another device you will have to help me with that.
 
 ## CTS400 / ES1077 (Comfort 250 Top)
 
-Experimental support for the **CTS400** controller (also labelled **ES1077**),
-as used in the **Nilan Comfort 250 Top**, is available as a separate board
-family. The CTS400 uses a completely different Modbus register space from the
-CTS602 above, so it is selected explicitly rather than auto-detected.
+Experimental support for the **CTS400** controller (also labelled **ES1077**), as used in the **Nilan Comfort 250 Top**, is available as a separate board family. The CTS400 uses a completely different Modbus register space from the CTS602 above, so it is selected explicitly rather than auto-detected.
 
-- **Pick the board during setup.** The config flow first asks which controller
-  board you have (CTS602 or CTS400). CTS400 cannot be auto-detected because it
-  has no `control_type` register, so the integration would otherwise reject it
-  as an unsupported device.
-- **Tested hardware.** Verified live on a Comfort 250 Top (CTS400, firmware 1.0)
-  over Modbus RTU (slave 30, 19200 8E1) through a Waveshare RS485 TO ETH (B)
-  bridge.
-- **CO2 / VOC are optional.** Those sensors appear only if the unit reports a
-  fitted extra sensor (holding register 48); on a base unit they are hidden.
-- **Ventilation control.** The unit is exposed as a `fan` entity with four speed
-  levels, and as a `climate` entity (FAN_ONLY) that combines the wanted room
-  temperature, run/stop and fan level into one thermostat card. A run/stop
-  switch and a fan-level number are also provided but disabled by default.
-- **Setpoints.** The wanted room temperature, the summer/winter switch-over
-  threshold, and the filter-change interval are exposed as adjustable numbers.
-  Note the season threshold is hysteretic: the unit leaves winter mode slowly
-  after the threshold is lowered.
-- **Alarms.** Raw alarm codes are exposed as diagnostic sensors; a code-to-name
-  mapping has not been confirmed for this controller and is therefore not
-  provided.
+- **Pick the board during setup.** The config flow first asks which controller board you have (CTS602 or CTS400). CTS400 cannot be auto-detected because it has no `control_type` register, so the integration would otherwise reject it as an unsupported device.
+- **Tested hardware.** Verified live on a Comfort 250 Top (CTS400, firmware 1.0) over Modbus RTU (slave 30, 19200 8E1) through a Waveshare RS485 TO ETH (B) bridge.
+- **CO2 / VOC are optional.** Those sensors appear only if the unit reports a fitted extra sensor (holding register 48); on a base unit they are hidden.
+- **Ventilation control.** The unit is exposed as a `fan` entity with four speed levels, and as a `climate` entity (FAN_ONLY) that combines the wanted room temperature, run/stop and fan level into one thermostat card. A run/stop switch and a fan-level number are also provided but disabled by default.
+- **Setpoints.** The wanted room temperature, the summer/winter switch-over threshold, and the filter-change interval are exposed as adjustable numbers. Note the season threshold is hysteretic: the unit leaves winter mode slowly after the threshold is lowered.
+- **Alarms.** Raw alarm codes are exposed as diagnostic sensors; a code-to-name mapping has not been confirmed for this controller and is therefore not provided.
 
-This support is a work in progress tracked in
-[discussion #165](https://github.com/veista/nilan/discussions/165). If you have a
-CTS400 / ES1077 unit, a debug log and a type-plate photo are very welcome.
+This support is a work in progress tracked in [discussion #165](https://github.com/veista/nilan/discussions/165). If you have a CTS400 / ES1077 unit, a debug log and a type-plate photo are very welcome.
 
 ## Installation
 ### Hardware

--- a/README.md
+++ b/README.md
@@ -44,7 +44,13 @@ CTS602 above, so it is selected explicitly rather than auto-detected.
 - **CO2 / VOC are optional.** Those sensors appear only if the unit reports a
   fitted extra sensor (holding register 48); on a base unit they are hidden.
 - **Ventilation control.** The unit is exposed as a `fan` entity with four speed
-  levels (plus a run/stop switch and a fan-level number).
+  levels, and as a `climate` entity (FAN_ONLY) that combines the wanted room
+  temperature, run/stop and fan level into one thermostat card. A run/stop
+  switch and a fan-level number are also provided but disabled by default.
+- **Setpoints.** The wanted room temperature, the summer/winter switch-over
+  threshold, and the filter-change interval are exposed as adjustable numbers.
+  Note the season threshold is hysteretic: the unit leaves winter mode slowly
+  after the threshold is lowered.
 - **Alarms.** Raw alarm codes are exposed as diagnostic sensors; a code-to-name
   mapping has not been confirmed for this controller and is therefore not
   provided.

--- a/README.md
+++ b/README.md
@@ -27,6 +27,32 @@ Majority of functions are supported. If some critical is missing please leave an
 
 If you have CTS700 or another device you will have to help me with that.
 
+## CTS400 / ES1077 (Comfort 250 Top)
+
+Experimental support for the **CTS400** controller (also labelled **ES1077**),
+as used in the **Nilan Comfort 250 Top**, is available as a separate board
+family. The CTS400 uses a completely different Modbus register space from the
+CTS602 above, so it is selected explicitly rather than auto-detected.
+
+- **Pick the board during setup.** The config flow first asks which controller
+  board you have (CTS602 or CTS400). CTS400 cannot be auto-detected because it
+  has no `control_type` register, so the integration would otherwise reject it
+  as an unsupported device.
+- **Tested hardware.** Verified live on a Comfort 250 Top (CTS400, firmware 1.0)
+  over Modbus RTU (slave 30, 19200 8E1) through a Waveshare RS485 TO ETH (B)
+  bridge.
+- **CO2 / VOC are optional.** Those sensors appear only if the unit reports a
+  fitted extra sensor (holding register 48); on a base unit they are hidden.
+- **Ventilation control.** The unit is exposed as a `fan` entity with four speed
+  levels (plus a run/stop switch and a fan-level number).
+- **Alarms.** Raw alarm codes are exposed as diagnostic sensors; a code-to-name
+  mapping has not been confirmed for this controller and is therefore not
+  provided.
+
+This support is a work in progress tracked in
+[discussion #165](https://github.com/veista/nilan/discussions/165). If you have a
+CTS400 / ES1077 unit, a debug log and a type-plate photo are very welcome.
+
 ## Installation
 ### Hardware
 You must have one interface type installed on your Nilan device for this Integration to work 

--- a/conftest.py
+++ b/conftest.py
@@ -1,6 +1,4 @@
-"""Ensure the repository root is importable so tests can do
-`from custom_components.nilan...` without installing the package.
+"""Ensure the repository root is importable so tests can do `from custom_components.nilan...` without installing the package.
 
-pytest imports this conftest from the repository root and, in the default
-"prepend" import mode, inserts this directory onto sys.path.
+pytest imports this conftest from the repository root and, in the default "prepend" import mode, inserts this directory onto sys.path.
 """

--- a/conftest.py
+++ b/conftest.py
@@ -1,0 +1,6 @@
+"""Ensure the repository root is importable so tests can do
+`from custom_components.nilan...` without installing the package.
+
+pytest imports this conftest from the repository root and, in the default
+"prepend" import mode, inserts this directory onto sys.path.
+"""

--- a/custom_components/nilan/__init__.py
+++ b/custom_components/nilan/__init__.py
@@ -36,9 +36,9 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     unit_id = entry.data["unit_id"]
     com_type = entry.data["com_type"]
     host_ip = entry.data["host_ip"]
-    # board_type = entry.data["board_type"]
+    board_type = entry.data.get("board_type", "CTS602")
 
-    device = Device(hass, name, com_type, host_ip, host_port, unit_id)
+    device = Device(hass, name, com_type, host_ip, host_port, unit_id, board_type)
     try:
         await device.setup()
     except ValueError as ex:

--- a/custom_components/nilan/__init__.py
+++ b/custom_components/nilan/__init__.py
@@ -16,6 +16,7 @@ PLATFORMS = [
     "binary_sensor",
     "button",
     "climate",
+    "fan",
     "number",
     "select",
     "sensor",

--- a/custom_components/nilan/binary_sensor.py
+++ b/custom_components/nilan/binary_sensor.py
@@ -135,6 +135,67 @@ ATTRIBUTE_TO_BINARY_SENSORS = {
             True,
         )
     ],
+    # --- CTS400 / ES1077 ---
+    "get_cts400_bypass_state": [
+        Map(
+            "cts400_bypass",
+            BinarySensorDeviceClass.OPENING,
+            None,
+            None,
+            None,
+            True,
+        )
+    ],
+    "get_cts400_filter_change_state": [
+        Map(
+            "cts400_filter_change",
+            BinarySensorDeviceClass.PROBLEM,
+            None,
+            None,
+            None,
+            True,
+        )
+    ],
+    "get_cts400_alarm_state": [
+        Map(
+            "cts400_alarm",
+            BinarySensorDeviceClass.PROBLEM,
+            None,
+            None,
+            None,
+            True,
+        )
+    ],
+    "get_cts400_winter_mode_state": [
+        Map(
+            "cts400_winter_mode",
+            None,
+            None,
+            "mdi:snowflake",
+            "mdi:weather-sunny",
+            True,
+        )
+    ],
+    "get_cts400_after_heating_state": [
+        Map(
+            "cts400_after_heating",
+            BinarySensorDeviceClass.RUNNING,
+            None,
+            "mdi:radiator",
+            "mdi:radiator-off",
+            True,
+        )
+    ],
+    "get_cts400_deicing_state": [
+        Map(
+            "cts400_deicing",
+            BinarySensorDeviceClass.RUNNING,
+            None,
+            "mdi:snowflake-melt",
+            None,
+            True,
+        )
+    ],
 }
 
 

--- a/custom_components/nilan/button.py
+++ b/custom_components/nilan/button.py
@@ -1,6 +1,8 @@
 """Platform for button integration."""
 from __future__ import annotations
 
+from collections import namedtuple
+
 from homeassistant.components.button import ButtonEntity
 from homeassistant.helpers.entity import EntityCategory
 from homeassistant.util.dt import now
@@ -8,14 +10,43 @@ from homeassistant.util.dt import now
 from .__init__ import NilanEntity
 from .const import DOMAIN
 
+Map = namedtuple("map", "name icon entity_category")
+
+ATTRIBUTE_TO_BUTTONS = {
+    "set_cts400_reset_filter_timer": Map(
+        "cts400_reset_filter_timer",
+        "mdi:air-filter",
+        EntityCategory.CONFIG,
+    ),
+    "set_cts400_reset_alarm": Map(
+        "cts400_reset_alarm",
+        "mdi:alarm-light-off-outline",
+        EntityCategory.CONFIG,
+    ),
+}
+
 
 async def async_setup_entry(HomeAssistant, config_entry, async_add_entities):
     """Set up the number platform."""
     device = HomeAssistant.data[DOMAIN][config_entry.entry_id]
     for attribute in device.get_assigned("button"):
-        if attribute in ("set_time"):
+        if attribute == "set_time":
             async_add_entities(
                 [NilanCTS602SyncTimeButton(device)], update_before_add=True
+            )
+        elif attribute in ATTRIBUTE_TO_BUTTONS:
+            entity = ATTRIBUTE_TO_BUTTONS[attribute]
+            async_add_entities(
+                [
+                    NilanButton(
+                        device,
+                        attribute,
+                        entity.name,
+                        entity.icon,
+                        entity.entity_category,
+                    )
+                ],
+                update_before_add=True,
             )
 
 
@@ -38,3 +69,22 @@ class NilanCTS602SyncTimeButton(ButtonEntity, NilanEntity):
     async def async_press(self) -> None:
         """Handle the button press."""
         await self._device.set_time(now())
+
+
+class NilanButton(ButtonEntity, NilanEntity):
+    """Representation of a Nilan write-1 action button."""
+
+    def __init__(self, device, attribute, name, icon, entity_category) -> None:
+        """Init the action button."""
+        super().__init__(device)
+        self._device = device
+        self._attribute = attribute
+        self._attr_entity_category = entity_category
+        self._attr_icon = icon
+        self._attr_translation_key = name
+        self._attr_has_entity_name = True
+        self._attr_unique_id = name
+
+    async def async_press(self) -> None:
+        """Handle the button press."""
+        await getattr(self._device, self._attribute)()

--- a/custom_components/nilan/climate.py
+++ b/custom_components/nilan/climate.py
@@ -96,7 +96,7 @@ async def async_setup_entry(HomeAssistant, config_entry, async_add_entities):
             NilanClimate(device, supported_features, extra_status_attributes)
         )
     if device.get_assigned("climate"):
-        entities.append(NilanCTS400Climate(device))
+        entities.append(NilanCTS400Climate(device, device.cts400_has_heater))
     async_add_entities(entities, True)
 
 
@@ -217,35 +217,44 @@ class NilanClimate(NilanEntity, ClimateEntity):
 
 
 class NilanCTS400Climate(NilanEntity, ClimateEntity):
-    """Minimal CTS400 climate: run/stop, target temperature and fan level.
+    """Minimal CTS400 climate: run/stop, fan level and (optionally) target temp.
 
-    The CTS400 has no HVAC-mode register and, on units without an after-heater
-    (holding 53 = 1, verified live on the reference unit), no active heating, so
-    it is modelled as FAN_ONLY / OFF. The target temperature drives the
-    after-heater only when one is fitted.
+    The CTS400 has no HVAC-mode register, so it is modelled as FAN_ONLY / OFF.
+    A target-temperature setpoint (holding 37) only has an observable effect
+    when an after-heater is fitted (holding 53 = 2 water / 3 electric); on a
+    base unit (holding 53 = 1, verified live on the reference unit) it is inert,
+    so TARGET_TEMPERATURE is only advertised when a heater is present.
+
+    Because it overlaps with the dedicated fan entity (the primary speed
+    control), this entity is disabled by default and can be enabled by users
+    who want a single thermostat card.
     """
 
     _attr_translation_key = "cts400_hvac"
     _attr_has_entity_name = True
     _attr_unique_id = "cts400_hvac"
+    _attr_entity_registry_enabled_default = False
     _attr_temperature_unit = UnitOfTemperature.CELSIUS
     _attr_hvac_modes = [HVACMode.FAN_ONLY, HVACMode.OFF]
     _attr_fan_modes = ["1", "2", "3", "4"]
     _attr_min_temp = 10
     _attr_max_temp = 30
     _attr_target_temperature_step = 0.5
-    _attr_supported_features = (
-        ClimateEntityFeature.TARGET_TEMPERATURE
-        | ClimateEntityFeature.FAN_MODE
-        | ClimateEntityFeature.TURN_ON
-        | ClimateEntityFeature.TURN_OFF
-    )
 
-    def __init__(self, device) -> None:
+    def __init__(self, device, has_heater) -> None:
         """Init the CTS400 climate entity."""
         super().__init__(device)
         self._device = device
+        self._has_heater = has_heater
         self._enable_turn_on_off_backwards_compatibility = False
+        supported = (
+            ClimateEntityFeature.FAN_MODE
+            | ClimateEntityFeature.TURN_ON
+            | ClimateEntityFeature.TURN_OFF
+        )
+        if has_heater:
+            supported |= ClimateEntityFeature.TARGET_TEMPERATURE
+        self._attr_supported_features = supported
 
     async def async_turn_on(self) -> None:
         """Start the unit."""
@@ -278,9 +287,10 @@ class NilanCTS400Climate(NilanEntity, ClimateEntity):
         is_on = await self._device.get_cts400_run_state()
         self._attr_hvac_mode = HVACMode.FAN_ONLY if is_on else HVACMode.OFF
         self._attr_hvac_action = HVACAction.FAN if is_on else HVACAction.OFF
-        self._attr_target_temperature = (
-            await self._device.get_cts400_wanted_room_temperature()
-        )
+        if self._attr_supported_features & ClimateEntityFeature.TARGET_TEMPERATURE:
+            self._attr_target_temperature = (
+                await self._device.get_cts400_wanted_room_temperature()
+            )
         self._attr_current_temperature = (
             await self._device.get_cts400_extract_temperature()
         )

--- a/custom_components/nilan/climate.py
+++ b/custom_components/nilan/climate.py
@@ -261,12 +261,15 @@ class NilanCTS400Climate(NilanEntity, ClimateEntity):
     async def async_set_hvac_mode(self, hvac_mode) -> None:
         """Run (FAN_ONLY) or stop (OFF) the unit."""
         await self._device.set_cts400_run_state(hvac_mode != HVACMode.OFF)
+        self._attr_hvac_mode = hvac_mode
         self.async_write_ha_state()
 
     async def async_set_fan_mode(self, fan_mode) -> None:
         """Set the fan level (1-4) and ensure the unit is running."""
         await self._device.set_cts400_fan_level_setpoint(int(fan_mode))
         await self._device.set_cts400_run_state(True)
+        self._attr_fan_mode = fan_mode
+        self._attr_hvac_mode = HVACMode.FAN_ONLY
         self.async_write_ha_state()
 
     async def async_set_temperature(self, **kwargs) -> None:
@@ -274,6 +277,7 @@ class NilanCTS400Climate(NilanEntity, ClimateEntity):
         temperature = kwargs.get(ATTR_TEMPERATURE)
         if temperature is not None:
             await self._device.set_cts400_wanted_room_temperature(temperature)
+            self._attr_target_temperature = temperature
         self.async_write_ha_state()
 
     async def async_update(self) -> None:

--- a/custom_components/nilan/climate.py
+++ b/custom_components/nilan/climate.py
@@ -219,15 +219,9 @@ class NilanClimate(NilanEntity, ClimateEntity):
 class NilanCTS400Climate(NilanEntity, ClimateEntity):
     """Minimal CTS400 climate: run/stop, fan level and (optionally) target temp.
 
-    The CTS400 has no HVAC-mode register, so it is modelled as FAN_ONLY / OFF.
-    A target-temperature setpoint (holding 37) only has an observable effect
-    when an after-heater is fitted (holding 53 = 2 water / 3 electric); on a
-    base unit (holding 53 = 1, verified live on the reference unit) it is inert,
-    so TARGET_TEMPERATURE is only advertised when a heater is present.
+    The CTS400 has no HVAC-mode register, so it is modelled as FAN_ONLY / OFF. A target-temperature setpoint (holding 37) only has an observable effect when an after-heater is fitted (holding 53 = 2 water / 3 electric); on a base unit (holding 53 = 1, verified live on the reference unit) it is inert, so TARGET_TEMPERATURE is only advertised when a heater is present.
 
-    Because it overlaps with the dedicated fan entity (the primary speed
-    control), this entity is disabled by default and can be enabled by users
-    who want a single thermostat card.
+    Because it overlaps with the dedicated fan entity (the primary speed control), this entity is disabled by default and can be enabled by users who want a single thermostat card.
     """
 
     _attr_translation_key = "cts400_hvac"

--- a/custom_components/nilan/climate.py
+++ b/custom_components/nilan/climate.py
@@ -95,6 +95,8 @@ async def async_setup_entry(HomeAssistant, config_entry, async_add_entities):
         entities.append(
             NilanClimate(device, supported_features, extra_status_attributes)
         )
+    if device.get_assigned("climate"):
+        entities.append(NilanCTS400Climate(device))
     async_add_entities(entities, True)
 
 
@@ -212,3 +214,77 @@ class NilanClimate(NilanEntity, ClimateEntity):
             self._attr_hvac_mode = HVAC_MODE_TO_STATE.get(
                 await self._device.get_operation_mode()
             )
+
+
+class NilanCTS400Climate(NilanEntity, ClimateEntity):
+    """Minimal CTS400 climate: run/stop, target temperature and fan level.
+
+    The CTS400 has no HVAC-mode register and, on units without an after-heater
+    (holding 53 = 1, verified live on the reference unit), no active heating, so
+    it is modelled as FAN_ONLY / OFF. The target temperature drives the
+    after-heater only when one is fitted.
+    """
+
+    _attr_translation_key = "cts400_hvac"
+    _attr_has_entity_name = True
+    _attr_unique_id = "cts400_hvac"
+    _attr_temperature_unit = UnitOfTemperature.CELSIUS
+    _attr_hvac_modes = [HVACMode.FAN_ONLY, HVACMode.OFF]
+    _attr_fan_modes = ["1", "2", "3", "4"]
+    _attr_min_temp = 10
+    _attr_max_temp = 30
+    _attr_target_temperature_step = 0.5
+    _attr_supported_features = (
+        ClimateEntityFeature.TARGET_TEMPERATURE
+        | ClimateEntityFeature.FAN_MODE
+        | ClimateEntityFeature.TURN_ON
+        | ClimateEntityFeature.TURN_OFF
+    )
+
+    def __init__(self, device) -> None:
+        """Init the CTS400 climate entity."""
+        super().__init__(device)
+        self._device = device
+        self._enable_turn_on_off_backwards_compatibility = False
+
+    async def async_turn_on(self) -> None:
+        """Start the unit."""
+        await self._device.set_cts400_run_state(True)
+
+    async def async_turn_off(self) -> None:
+        """Stop the unit."""
+        await self._device.set_cts400_run_state(False)
+
+    async def async_set_hvac_mode(self, hvac_mode) -> None:
+        """Run (FAN_ONLY) or stop (OFF) the unit."""
+        await self._device.set_cts400_run_state(hvac_mode != HVACMode.OFF)
+        self.async_write_ha_state()
+
+    async def async_set_fan_mode(self, fan_mode) -> None:
+        """Set the fan level (1-4) and ensure the unit is running."""
+        await self._device.set_cts400_fan_level_setpoint(int(fan_mode))
+        await self._device.set_cts400_run_state(True)
+        self.async_write_ha_state()
+
+    async def async_set_temperature(self, **kwargs) -> None:
+        """Set the wanted room temperature."""
+        temperature = kwargs.get(ATTR_TEMPERATURE)
+        if temperature is not None:
+            await self._device.set_cts400_wanted_room_temperature(temperature)
+        self.async_write_ha_state()
+
+    async def async_update(self) -> None:
+        """Refresh run state, temperatures and fan level."""
+        is_on = await self._device.get_cts400_run_state()
+        self._attr_hvac_mode = HVACMode.FAN_ONLY if is_on else HVACMode.OFF
+        self._attr_hvac_action = HVACAction.FAN if is_on else HVACAction.OFF
+        self._attr_target_temperature = (
+            await self._device.get_cts400_wanted_room_temperature()
+        )
+        self._attr_current_temperature = (
+            await self._device.get_cts400_extract_temperature()
+        )
+        level = await self._device.get_cts400_fan_level()
+        if not level:
+            level = await self._device.get_cts400_fan_level_setpoint()
+        self._attr_fan_mode = str(level) if level else None

--- a/custom_components/nilan/config_flow.py
+++ b/custom_components/nilan/config_flow.py
@@ -13,7 +13,7 @@ from homeassistant import config_entries
 
 from .const import DOMAIN
 from .device import CTS602_DEVICE_TYPES
-from .registers import CTS602HoldingRegisters
+from .registers import CTS400HoldingRegisters, CTS602HoldingRegisters
 
 STEP_TCP_DATA_SCHEMA = vol.Schema(
     {
@@ -34,7 +34,9 @@ STEP_SERIAL_DATA_SCHEMA = vol.Schema(
 
 _LOGGER = logging.getLogger(__name__)
 
-async def async_validate_device(com_type, port, unit_id, address: str | None) -> None:
+async def async_validate_device(
+    com_type, port, unit_id, address: str | None, board_type: str = "CTS602"
+) -> None:
     """Validate device model."""
     if com_type == "tcp":
         client = AsyncModbusTcpClient(
@@ -50,6 +52,27 @@ async def async_validate_device(com_type, port, unit_id, address: str | None) ->
             baudrate=19200,
             timeout=1,
         )
+    if board_type == "CTS400":
+        # The CTS400 / ES1077 has no control_type register and cannot be
+        # auto-detected, so the board is selected manually in the flow. Reading
+        # the run/stop register (holding 70, which always exists) is used purely
+        # as a reachability probe to confirm the unit answers FC03.
+        try:
+            await client.connect()
+            result = await client.read_holding_registers(
+                CTS400HoldingRegisters.run_stop, count=1, device_id=int(unit_id)
+            )
+        except ModbusException as value_error:
+            client.close()
+            raise ValueError("cannot_connect") from value_error
+        if hasattr(result, "message"):
+            client.close()
+            raise ValueError("invalid_response")
+        if len(result.registers) == 0:
+            client.close()
+            raise ValueError("invalid_response")
+        client.close()
+        return
     try:
         await client.connect()
         result = await client.read_holding_registers(
@@ -84,9 +107,27 @@ class NilanConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
     VERSION = 3
 
     data: Optional[dict(str, Any)]
+    _board_type: str = "CTS602"
 
     async def async_step_user(self, user_input: Optional[dict(str, Any)] = None):
         """Invoke when a user initiates a flow via the user interface."""
+        return await self.async_step_board(user_input)
+
+    async def async_step_board(self, user_input: Optional[dict(str, Any)] = None):
+        """Show controller board selection."""
+        return self.async_show_menu(
+            step_id="board",
+            menu_options=["cts602", "cts400"],
+        )
+
+    async def async_step_cts602(self, user_input: Optional[dict(str, Any)] = None):
+        """Select the CTS602 controller family."""
+        self._board_type = "CTS602"
+        return await self.async_step_menu(user_input)
+
+    async def async_step_cts400(self, user_input: Optional[dict(str, Any)] = None):
+        """Select the CTS400 / ES1077 controller family."""
+        self._board_type = "CTS400"
         return await self.async_step_menu(user_input)
 
     async def async_step_menu(self, user_input: Optional[dict(str, Any)] = None):
@@ -110,6 +151,7 @@ class NilanConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
                     user_input["host_port"],
                     user_input["unit_id"],
                     user_input["host_ip"],
+                    self._board_type,
                 )
             except ValueError as error:
                 errors["base"] = str(error)
@@ -117,7 +159,7 @@ class NilanConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
                 # Input is valid, set data.
                 self.data = user_input
                 self.data.update({"com_type": "tcp"})
-                self.data.update({"board_type": "CTS602"})
+                self.data.update({"board_type": self._board_type})
                 return self.async_create_entry(title=user_input["name"], data=self.data)
         return self.async_show_form(
             step_id="tcp", data_schema=STEP_TCP_DATA_SCHEMA, errors=errors
@@ -130,7 +172,11 @@ class NilanConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
         if user_input is not None:
             try:
                 await async_validate_device(
-                    "serial", user_input["host_port"], user_input["unit_id"], None
+                    "serial",
+                    user_input["host_port"],
+                    user_input["unit_id"],
+                    None,
+                    self._board_type,
                 )
             except ValueError as error:
                 errors["base"] = str(error)
@@ -139,7 +185,7 @@ class NilanConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
                 self.data = user_input
                 self.data.update({"com_type": "serial"})
                 self.data.update({"host_ip": None})
-                self.data.update({"board_type": "CTS602"})
+                self.data.update({"board_type": self._board_type})
                 return self.async_create_entry(title=user_input["name"], data=self.data)
         return self.async_show_form(
             step_id="serial", data_schema=STEP_SERIAL_DATA_SCHEMA, errors=errors

--- a/custom_components/nilan/cts400_util.py
+++ b/custom_components/nilan/cts400_util.py
@@ -1,8 +1,6 @@
 """Pure helpers for the CTS400 board.
 
-Deliberately free of Home Assistant and pymodbus imports so the behavioural
-logic (fan percentage <-> level mapping and signed-register decoding) can be
-unit-tested without an HA harness.
+Deliberately free of Home Assistant and pymodbus imports so the behavioural logic (fan percentage <-> level mapping and signed-register decoding) can be unit-tested without an HA harness.
 """
 from __future__ import annotations
 
@@ -13,8 +11,7 @@ _STEP = 100 / SPEED_COUNT  # 25 % per level
 def percentage_to_level(percentage: float) -> int:
     """Map a 0-100 % onto fan level 0-4 (0 = off).
 
-    Uses round-half-up (not Python's banker's rounding) so a value sitting
-    exactly on a .5 boundary rounds to the higher level predictably.
+    Uses round-half-up (not Python's banker's rounding) so a value sitting exactly on a .5 boundary rounds to the higher level predictably.
     """
     level = int(percentage / _STEP + 0.5)
     return max(0, min(SPEED_COUNT, level))

--- a/custom_components/nilan/cts400_util.py
+++ b/custom_components/nilan/cts400_util.py
@@ -1,0 +1,30 @@
+"""Pure helpers for the CTS400 board.
+
+Deliberately free of Home Assistant and pymodbus imports so the behavioural
+logic (fan percentage <-> level mapping and signed-register decoding) can be
+unit-tested without an HA harness.
+"""
+from __future__ import annotations
+
+SPEED_COUNT = 4
+_STEP = 100 / SPEED_COUNT  # 25 % per level
+
+
+def percentage_to_level(percentage: float) -> int:
+    """Map a 0-100 % onto fan level 0-4 (0 = off).
+
+    Uses round-half-up (not Python's banker's rounding) so a value sitting
+    exactly on a .5 boundary rounds to the higher level predictably.
+    """
+    level = int(percentage / _STEP + 0.5)
+    return max(0, min(SPEED_COUNT, level))
+
+
+def level_to_percentage(level: int) -> int:
+    """Map a fan level 1-4 onto its percentage (25/50/75/100)."""
+    return int(round(level * _STEP))
+
+
+def decode_signed16(raw: int) -> int:
+    """Reinterpret an unsigned 16-bit register value as a signed int16."""
+    return raw - 0x10000 if raw >= 0x8000 else raw

--- a/custom_components/nilan/device.py
+++ b/custom_components/nilan/device.py
@@ -3962,6 +3962,10 @@ class Device:
         # rather than invent a value.
         self._device_sw_ver = ""
         extra_sensor = await self.get_cts400_extra_sensor_type()
+        # A target-temperature setpoint only has an observable effect when an
+        # after-heater is fitted (holding 53 = 2 water / 3 electric); on a base
+        # unit it is inert, so the climate entity drops TARGET_TEMPERATURE.
+        self._cts400_has_heater = await self.get_cts400_heater_type() in (2, 3)
         for entity, value in CTS400_ENTITY_MAP.items():
             extra_type = value.get("extra_type")
             if extra_type == "co2" and extra_sensor != 2:
@@ -3969,6 +3973,18 @@ class Device:
             if extra_type == "voc" and extra_sensor != 1:
                 continue
             self._attributes[entity] = value["entity_type"]
+
+    @property
+    def cts400_has_heater(self) -> bool:
+        """Whether an after-heater is fitted (holding 53 = 2 or 3)."""
+        return getattr(self, "_cts400_has_heater", False)
+
+    async def get_cts400_heater_type(self) -> int:
+        """Get the after-heater option (0/1 = none, 2 = water, 3 = electric)."""
+        value = await self._read_cts400_register(
+            CTS400HoldingRegisters.heater_select, "holding"
+        )
+        return 0 if value is None else value
 
     async def get_cts400_extra_sensor_type(self) -> int:
         """Get the fitted extra sensor (0 = none, 1 = VOC, 2 = CO2)."""
@@ -4231,6 +4247,10 @@ class Device:
 
     async def set_cts400_filter_interval(self, value) -> bool:
         """Set CTS400 filter-change interval (holding 50, 0-360 days).
+
+        The hardware accepts 0-360; 0 means "always due", so the number entity
+        exposes a 1-360 range to avoid that foot-gun while the setter still
+        accepts the full documented hardware range.
 
         Live-verified: writing this register immediately updates the
         filter-days-remaining countdown (input 110).

--- a/custom_components/nilan/device.py
+++ b/custom_components/nilan/device.py
@@ -19,6 +19,7 @@ from .registers import (
     CTS602HoldingRegisters,
     CTS602InputRegisters,
 )
+from .cts400_util import decode_signed16
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -3929,11 +3930,8 @@ class Device:
             self._unit_id, address, 1, reg_type
         )
         if result is not None:
-            return int.from_bytes(
-                result.registers[0].to_bytes(2, "little", signed=False),
-                "little",
-                signed=signed,
-            )
+            raw = result.registers[0]
+            return decode_signed16(raw) if signed else raw
         _LOGGER.error("Could not read CTS400 register %s (%s)", address, reg_type)
         return None
 

--- a/custom_components/nilan/device.py
+++ b/custom_components/nilan/device.py
@@ -4123,6 +4123,15 @@ class Device:
 
     # --- CTS400 switch (run/stop) ---
 
+    async def get_cts400_fan(self) -> bool:
+        """CTS400 ventilation-fan handle (used by the fan platform).
+
+        The fan entity reads run state plus the current/setpoint level
+        directly; this method exists so the fan has an entity-map key and
+        mirrors the run/stop state for a quick reachability read.
+        """
+        return await self.get_cts400_run_state()
+
     async def get_cts400_run_state(self) -> bool:
         """Get CTS400 run/stop state (holding 70; 1 = run, 0 = stop)."""
         value = await self._read_cts400_register(

--- a/custom_components/nilan/device.py
+++ b/custom_components/nilan/device.py
@@ -3947,10 +3947,7 @@ class Device:
     async def _setup_cts400(self):
         """Build the entity map for a CTS400 / ES1077 board.
 
-        The CTS400 cannot be auto-detected (it has no control_type register),
-        so the board is selected in the config flow. A read of the run/stop
-        register (holding 70) is used purely as a reachability probe. CO2/VOC
-        entities are gated on the fitted extra sensor (holding 48).
+        The CTS400 cannot be auto-detected (it has no control_type register), so the board is selected in the config flow. A read of the run/stop register (holding 70) is used purely as a reachability probe. CO2/VOC entities are gated on the fitted extra sensor (holding 48).
         """
         probe = await self.get_cts400_run_state()
         if probe is None:
@@ -4142,9 +4139,7 @@ class Device:
     async def get_cts400_fan(self) -> bool:
         """CTS400 ventilation-fan handle (used by the fan platform).
 
-        The fan entity reads run state plus the current/setpoint level
-        directly; this method exists so the fan has an entity-map key and
-        mirrors the run/stop state for a quick reachability read.
+        The fan entity reads run state plus the current/setpoint level directly; this method exists so the fan has an entity-map key and mirrors the run/stop state for a quick reachability read.
         """
         return await self.get_cts400_run_state()
 
@@ -4188,10 +4183,7 @@ class Device:
     async def set_cts400_wanted_room_temperature(self, value) -> bool:
         """Set CTS400 wanted room temperature (holding 37, 10.0-30.0 C).
 
-        Live-verified (2026-06-14): write + exact read-back proven on the unit,
-        and the controller itself rejects out-of-range writes (9.0 and 31.0 C
-        left the value unchanged), so the hardware enforces the documented
-        10-30 C range on top of this software clamp (100-300 raw).
+        Live-verified (2026-06-14): write + exact read-back proven on the unit, and the controller itself rejects out-of-range writes (9.0 and 31.0 C left the value unchanged), so the hardware enforces the documented 10-30 C range on top of this software clamp (100-300 raw).
         """
         raw = int(round(float(value) * 10))
         if 100 <= raw <= 300:
@@ -4226,11 +4218,7 @@ class Device:
     async def set_cts400_summer_winter_threshold(self, value) -> bool:
         """Set CTS400 summer/winter threshold (holding 45, 5.0-20.0 C).
 
-        Live-verified: writing this register moves winter mode (input 72) by
-        comparison against the live outdoor temperature. Entry into winter is
-        fast (~40 s); exit is strongly hysteretic (the season state machine
-        latches winter and leaves it only slowly). Writes are clamped to the
-        documented 50-200 raw range.
+        Live-verified: writing this register moves winter mode (input 72) by comparison against the live outdoor temperature. Entry into winter is fast (~40 s); exit is strongly hysteretic (the season state machine latches winter and leaves it only slowly). Writes are clamped to the documented 50-200 raw range.
         """
         raw = int(round(float(value) * 10))
         if 50 <= raw <= 200:
@@ -4248,12 +4236,9 @@ class Device:
     async def set_cts400_filter_interval(self, value) -> bool:
         """Set CTS400 filter-change interval (holding 50, 0-360 days).
 
-        The hardware accepts 0-360; 0 means "always due", so the number entity
-        exposes a 1-360 range to avoid that foot-gun while the setter still
-        accepts the full documented hardware range.
+        The hardware accepts 0-360; 0 means "always due", so the number entity exposes a 1-360 range to avoid that foot-gun while the setter still accepts the full documented hardware range.
 
-        Live-verified: writing this register immediately updates the
-        filter-days-remaining countdown (input 110).
+        Live-verified: writing this register immediately updates the filter-days-remaining countdown (input 110).
         """
         raw = int(value)
         if 0 <= raw <= 360:
@@ -4265,9 +4250,6 @@ class Device:
     async def get_cts400_climate(self) -> bool:
         """CTS400 climate handle (used by the climate platform).
 
-        The climate entity reads run state, the wanted-temperature setpoint,
-        the extract (room) temperature and the fan level directly; this method
-        exists so the climate entity has an entity-map key and mirrors the
-        run/stop state for a quick reachability read.
+        The climate entity reads run state, the wanted-temperature setpoint, the extract (room) temperature and the fan level directly; this method exists so the climate entity has an entity-map key and mirrors the run/stop state for a quick reachability read.
         """
         return await self.get_cts400_run_state()

--- a/custom_components/nilan/device.py
+++ b/custom_components/nilan/device.py
@@ -4172,8 +4172,10 @@ class Device:
     async def set_cts400_wanted_room_temperature(self, value) -> bool:
         """Set CTS400 wanted room temperature (holding 37, 10.0-30.0 C).
 
-        Protocol-verified register; not exercised by the live reference
-        package. Writes are clamped to the documented 100-300 raw range.
+        Live-verified (2026-06-14): write + exact read-back proven on the unit,
+        and the controller itself rejects out-of-range writes (9.0 and 31.0 C
+        left the value unchanged), so the hardware enforces the documented
+        10-30 C range on top of this software clamp (100-300 raw).
         """
         raw = int(round(float(value) * 10))
         if 100 <= raw <= 300:
@@ -4195,3 +4197,57 @@ class Device:
         return await self._write_cts400_holding(
             CTS400HoldingRegisters.reset_alarm, 1
         )
+
+    # --- CTS400 regulation setpoints (live-verified 2026-06-14) ---
+
+    async def get_cts400_summer_winter_threshold(self) -> float:
+        """Get CTS400 summer/winter threshold (holding 45, scale 0.1)."""
+        value = await self._read_cts400_register(
+            CTS400HoldingRegisters.summer_winter_threshold, "holding", signed=True
+        )
+        return None if value is None else float(value) / 10
+
+    async def set_cts400_summer_winter_threshold(self, value) -> bool:
+        """Set CTS400 summer/winter threshold (holding 45, 5.0-20.0 C).
+
+        Live-verified: writing this register moves winter mode (input 72) by
+        comparison against the live outdoor temperature. Entry into winter is
+        fast (~40 s); exit is strongly hysteretic (the season state machine
+        latches winter and leaves it only slowly). Writes are clamped to the
+        documented 50-200 raw range.
+        """
+        raw = int(round(float(value) * 10))
+        if 50 <= raw <= 200:
+            return await self._write_cts400_holding(
+                CTS400HoldingRegisters.summer_winter_threshold, raw
+            )
+        return False
+
+    async def get_cts400_filter_interval(self) -> int:
+        """Get CTS400 filter-change interval in days (holding 50)."""
+        return await self._read_cts400_register(
+            CTS400HoldingRegisters.filter_interval, "holding"
+        )
+
+    async def set_cts400_filter_interval(self, value) -> bool:
+        """Set CTS400 filter-change interval (holding 50, 0-360 days).
+
+        Live-verified: writing this register immediately updates the
+        filter-days-remaining countdown (input 110).
+        """
+        raw = int(value)
+        if 0 <= raw <= 360:
+            return await self._write_cts400_holding(
+                CTS400HoldingRegisters.filter_interval, raw
+            )
+        return False
+
+    async def get_cts400_climate(self) -> bool:
+        """CTS400 climate handle (used by the climate platform).
+
+        The climate entity reads run state, the wanted-temperature setpoint,
+        the extract (room) temperature and the fan level directly; this method
+        exists so the climate entity has an entity-map key and mirrors the
+        run/stop state for a quick reachability read.
+        """
+        return await self.get_cts400_run_state()

--- a/custom_components/nilan/device.py
+++ b/custom_components/nilan/device.py
@@ -8,8 +8,17 @@ import logging
 from homeassistant.components.modbus import modbus
 from homeassistant.core import HomeAssistant
 
-from .device_map import CTS602_DEVICE_TYPES, CTS602_ENTITY_MAP
-from .registers import CTS602HoldingRegisters, CTS602InputRegisters
+from .device_map import (
+    CTS400_ENTITY_MAP,
+    CTS602_DEVICE_TYPES,
+    CTS602_ENTITY_MAP,
+)
+from .registers import (
+    CTS400HoldingRegisters,
+    CTS400InputRegisters,
+    CTS602HoldingRegisters,
+    CTS602InputRegisters,
+)
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -25,6 +34,7 @@ class Device:
         host_ip: str | None,
         host_port,
         unit_id,
+        board_type: str = "CTS602",
     ) -> None:
         """Create new entity of Device Class."""
         self.hass = hass
@@ -36,6 +46,7 @@ class Device:
         self._host_port = host_port
         self._unit_id = int(unit_id)
         self._com_type = com_type
+        self._board_type = board_type
         self._client_config = {
             "name": self._device_name,
             "type": self._com_type,
@@ -70,6 +81,10 @@ class Device:
             await self._modbus.async_close()
             _LOGGER.error("Modbus setup was unsuccessful")
             raise ValueError("Modbus setup was unsuccessful")
+
+        if self._board_type == "CTS400":
+            await self._setup_cts400()
+            return
 
         hw_type = await self.get_machine_type()
         _LOGGER.debug("Device Type = %s", str(hw_type))
@@ -3894,4 +3909,280 @@ class Device:
             CTS602HoldingRegisters.hps_param_main_switch,
             [value],
             "write_registers",
+        )
+
+    # -----------------------------------------------------------------------
+    # CTS400 / ES1077 (Comfort 250 Top) - separate board family
+    #
+    # Only used when board_type == "CTS400". The CTS400 register space is
+    # unrelated to the CTS602 methods above. Two board-specific differences:
+    #   * temperatures, humidity and air percentages use one decimal
+    #     (scale 0.1, divide by 10) - the CTS602 uses two decimals (0.01);
+    #   * the controller only supports FC06 (write single register), so writes
+    #     use "write_register", not the CTS602's "write_registers" (FC16).
+    # Every address below is verified live on the operator's unit.
+    # -----------------------------------------------------------------------
+
+    async def _read_cts400_register(self, address, reg_type, signed=False):
+        """Read one CTS400 input/holding register and return it as an int."""
+        result = await self._modbus.async_pb_call(
+            self._unit_id, address, 1, reg_type
+        )
+        if result is not None:
+            return int.from_bytes(
+                result.registers[0].to_bytes(2, "little", signed=False),
+                "little",
+                signed=signed,
+            )
+        _LOGGER.error("Could not read CTS400 register %s (%s)", address, reg_type)
+        return None
+
+    async def _write_cts400_holding(self, address, value) -> bool:
+        """Write one CTS400 holding register using FC06 (Preset Single)."""
+        await self._modbus.async_pb_call(
+            self._unit_id, address, int(value), "write_register"
+        )
+        return True
+
+    async def _setup_cts400(self):
+        """Build the entity map for a CTS400 / ES1077 board.
+
+        The CTS400 cannot be auto-detected (it has no control_type register),
+        so the board is selected in the config flow. A read of the run/stop
+        register (holding 70) is used purely as a reachability probe. CO2/VOC
+        entities are gated on the fitted extra sensor (holding 48).
+        """
+        probe = await self.get_cts400_run_state()
+        if probe is None:
+            await self._modbus.async_close()
+            _LOGGER.error("CTS400 did not respond to holding register 70")
+            raise ValueError("CTS400 probe returned None")
+        self._device_type = CTS400_DEVICE_TYPES[0]
+        # No verified software-version register on this firmware; leave blank
+        # rather than invent a value.
+        self._device_sw_ver = ""
+        extra_sensor = await self.get_cts400_extra_sensor_type()
+        for entity, value in CTS400_ENTITY_MAP.items():
+            extra_type = value.get("extra_type")
+            if extra_type == "co2" and extra_sensor != 2:
+                continue
+            if extra_type == "voc" and extra_sensor != 1:
+                continue
+            self._attributes[entity] = value["entity_type"]
+
+    async def get_cts400_extra_sensor_type(self) -> int:
+        """Get the fitted extra sensor (0 = none, 1 = VOC, 2 = CO2)."""
+        value = await self._read_cts400_register(
+            CTS400HoldingRegisters.extra_sensor, "holding"
+        )
+        return 0 if value is None else value
+
+    # --- CTS400 sensors ---
+
+    async def get_cts400_outdoor_temperature(self) -> float:
+        """Get CTS400 T1 outdoor (fresh-air intake) temperature."""
+        value = await self._read_cts400_register(
+            CTS400InputRegisters.t1_outdoor, "input", signed=True
+        )
+        return None if value is None else float(value) / 10
+
+    async def get_cts400_supply_temperature(self) -> float:
+        """Get CTS400 T2 supply (to rooms) temperature."""
+        value = await self._read_cts400_register(
+            CTS400InputRegisters.t2_supply, "input", signed=True
+        )
+        return None if value is None else float(value) / 10
+
+    async def get_cts400_extract_temperature(self) -> float:
+        """Get CTS400 T3 extract (from rooms) temperature."""
+        value = await self._read_cts400_register(
+            CTS400InputRegisters.t3_extract, "input", signed=True
+        )
+        return None if value is None else float(value) / 10
+
+    async def get_cts400_exhaust_temperature(self) -> float:
+        """Get CTS400 T4 exhaust (out) temperature."""
+        value = await self._read_cts400_register(
+            CTS400InputRegisters.t4_exhaust, "input", signed=True
+        )
+        return None if value is None else float(value) / 10
+
+    async def get_cts400_humidity(self) -> float:
+        """Get CTS400 relative humidity."""
+        value = await self._read_cts400_register(
+            CTS400InputRegisters.humidity, "input"
+        )
+        return None if value is None else float(value) / 10
+
+    async def get_cts400_extract_air_capacity(self) -> float:
+        """Get CTS400 extract air fan capacity (%)."""
+        value = await self._read_cts400_register(
+            CTS400InputRegisters.extract_air_pct, "input"
+        )
+        return None if value is None else float(value) / 10
+
+    async def get_cts400_supply_air_capacity(self) -> float:
+        """Get CTS400 supply air fan capacity (%)."""
+        value = await self._read_cts400_register(
+            CTS400InputRegisters.supply_air_pct, "input"
+        )
+        return None if value is None else float(value) / 10
+
+    async def get_cts400_after_heating_capacity(self) -> float:
+        """Get CTS400 after-heating element capacity (%)."""
+        value = await self._read_cts400_register(
+            CTS400InputRegisters.after_heat_pct, "input"
+        )
+        return None if value is None else float(value) / 10
+
+    async def get_cts400_fan_level(self) -> int:
+        """Get CTS400 current fan level (1-4; 0 when stopped)."""
+        return await self._read_cts400_register(
+            CTS400InputRegisters.fan_level, "input"
+        )
+
+    async def get_cts400_filter_days_remaining(self) -> int:
+        """Get CTS400 days remaining before filter change."""
+        return await self._read_cts400_register(
+            CTS400InputRegisters.filter_days_remaining, "input"
+        )
+
+    async def get_cts400_alarm_code_1(self) -> int:
+        """Get CTS400 raw alarm code 1 (idles at 49 with no alarm)."""
+        return await self._read_cts400_register(
+            CTS400InputRegisters.alarm_code_1, "input"
+        )
+
+    async def get_cts400_alarm_code_2(self) -> int:
+        """Get CTS400 raw alarm code 2 (idles at 49 with no alarm)."""
+        return await self._read_cts400_register(
+            CTS400InputRegisters.alarm_code_2, "input"
+        )
+
+    async def get_cts400_alarm_code_3(self) -> int:
+        """Get CTS400 raw alarm code 3 (idles at 0 with no alarm)."""
+        return await self._read_cts400_register(
+            CTS400InputRegisters.alarm_code_3, "input"
+        )
+
+    async def get_cts400_co2(self) -> int:
+        """Get CTS400 CO2 (ppm); only if a CO2 extra sensor is fitted."""
+        return await self._read_cts400_register(
+            CTS400InputRegisters.co2, "input"
+        )
+
+    async def get_cts400_voc(self) -> int:
+        """Get CTS400 VOC (ppm); only if a VOC extra sensor is fitted."""
+        return await self._read_cts400_register(
+            CTS400InputRegisters.voc, "input"
+        )
+
+    # --- CTS400 binary sensors ---
+
+    async def get_cts400_bypass_state(self) -> bool:
+        """Get CTS400 bypass damper state (1 = open)."""
+        value = await self._read_cts400_register(
+            CTS400InputRegisters.bypass_open, "input"
+        )
+        return None if value is None else bool(value)
+
+    async def get_cts400_filter_change_state(self) -> bool:
+        """Get CTS400 filter-change-due state (1 = change due)."""
+        value = await self._read_cts400_register(
+            CTS400InputRegisters.filter_change, "input"
+        )
+        return None if value is None else bool(value)
+
+    async def get_cts400_alarm_state(self) -> bool:
+        """Get CTS400 alarm state (input 50; 0 = no alarm)."""
+        value = await self._read_cts400_register(
+            CTS400InputRegisters.alarm_status, "input"
+        )
+        return None if value is None else bool(value)
+
+    async def get_cts400_winter_mode_state(self) -> bool:
+        """Get CTS400 season state (0 = summer, 1 = winter)."""
+        value = await self._read_cts400_register(
+            CTS400InputRegisters.mode_winter, "input"
+        )
+        return None if value is None else bool(value)
+
+    async def get_cts400_after_heating_state(self) -> bool:
+        """Get CTS400 after-heating active state."""
+        value = await self._read_cts400_register(
+            CTS400InputRegisters.after_heating, "input"
+        )
+        return None if value is None else bool(value)
+
+    async def get_cts400_deicing_state(self) -> bool:
+        """Get CTS400 de-icing active state (1 = on)."""
+        value = await self._read_cts400_register(
+            CTS400InputRegisters.deicing, "input"
+        )
+        return None if value is None else bool(value)
+
+    # --- CTS400 switch (run/stop) ---
+
+    async def get_cts400_run_state(self) -> bool:
+        """Get CTS400 run/stop state (holding 70; 1 = run, 0 = stop)."""
+        value = await self._read_cts400_register(
+            CTS400HoldingRegisters.run_stop, "holding"
+        )
+        return None if value is None else bool(value)
+
+    async def set_cts400_run_state(self, state) -> bool:
+        """Set CTS400 run/stop (holding 70: 1 = run, 0 = stop)."""
+        return await self._write_cts400_holding(
+            CTS400HoldingRegisters.run_stop, 1 if state else 0
+        )
+
+    # --- CTS400 numbers (setpoints) ---
+
+    async def get_cts400_fan_level_setpoint(self) -> int:
+        """Get CTS400 fan-level setpoint (holding 69, 1-4)."""
+        return await self._read_cts400_register(
+            CTS400HoldingRegisters.fan_level_set, "holding"
+        )
+
+    async def set_cts400_fan_level_setpoint(self, value) -> bool:
+        """Set CTS400 fan-level setpoint (holding 69, 1-4)."""
+        value = int(value)
+        if value in (1, 2, 3, 4):
+            return await self._write_cts400_holding(
+                CTS400HoldingRegisters.fan_level_set, value
+            )
+        return False
+
+    async def get_cts400_wanted_room_temperature(self) -> float:
+        """Get CTS400 wanted room temperature (holding 37, scale 0.1)."""
+        value = await self._read_cts400_register(
+            CTS400HoldingRegisters.wanted_room_temp, "holding", signed=True
+        )
+        return None if value is None else float(value) / 10
+
+    async def set_cts400_wanted_room_temperature(self, value) -> bool:
+        """Set CTS400 wanted room temperature (holding 37, 10.0-30.0 C).
+
+        Protocol-verified register; not exercised by the live reference
+        package. Writes are clamped to the documented 100-300 raw range.
+        """
+        raw = int(round(float(value) * 10))
+        if 100 <= raw <= 300:
+            return await self._write_cts400_holding(
+                CTS400HoldingRegisters.wanted_room_temp, raw
+            )
+        return False
+
+    # --- CTS400 buttons (momentary, write-1 self-clearing) ---
+
+    async def set_cts400_reset_filter_timer(self) -> bool:
+        """Reset the CTS400 filter-change timer (write 1 to holding 51)."""
+        return await self._write_cts400_holding(
+            CTS400HoldingRegisters.reset_filter_timer, 1
+        )
+
+    async def set_cts400_reset_alarm(self) -> bool:
+        """Reset CTS400 alarms (write 1 to holding 30)."""
+        return await self._write_cts400_holding(
+            CTS400HoldingRegisters.reset_alarm, 1
         )

--- a/custom_components/nilan/device_map.py
+++ b/custom_components/nilan/device_map.py
@@ -1841,3 +1841,53 @@ CTS602_ENTITY_MAP = {
         "supported_devices": ("all",),
     },
 }
+
+# ---------------------------------------------------------------------------
+# CTS400 / ES1077 (Comfort 250 Top)
+#
+# The CTS400 is a separate board family with its own register space (see
+# registers.CTS400*Registers). It cannot be auto-detected the way the CTS602 is
+# (it has no control_type register at holding 1000), so the config flow selects
+# it explicitly and the entity set below is assigned verbatim - there is no
+# bus-version gating. Every address backing these entities is verified live.
+# ---------------------------------------------------------------------------
+
+CTS400_DEVICE_TYPES = {
+    # The CTS400 has no machine-type register to read back, so this is a single
+    # logical type selected via the config-flow board picker.
+    0: "Comfort 250 Top (ES1077/CTS400)",
+}
+
+CTS400_ENTITY_MAP = {
+    # --- sensors ---
+    "get_cts400_outdoor_temperature": {"entity_type": "sensor"},
+    "get_cts400_supply_temperature": {"entity_type": "sensor"},
+    "get_cts400_extract_temperature": {"entity_type": "sensor"},
+    "get_cts400_exhaust_temperature": {"entity_type": "sensor"},
+    "get_cts400_humidity": {"entity_type": "sensor"},
+    "get_cts400_extract_air_capacity": {"entity_type": "sensor"},
+    "get_cts400_supply_air_capacity": {"entity_type": "sensor"},
+    "get_cts400_after_heating_capacity": {"entity_type": "sensor"},
+    "get_cts400_fan_level": {"entity_type": "sensor"},
+    "get_cts400_filter_days_remaining": {"entity_type": "sensor"},
+    "get_cts400_alarm_code_1": {"entity_type": "sensor"},
+    "get_cts400_alarm_code_2": {"entity_type": "sensor"},
+    "get_cts400_alarm_code_3": {"entity_type": "sensor"},
+    "get_cts400_co2": {"entity_type": "sensor", "extra_type": "co2"},
+    "get_cts400_voc": {"entity_type": "sensor", "extra_type": "voc"},
+    # --- binary sensors ---
+    "get_cts400_bypass_state": {"entity_type": "binary_sensor"},
+    "get_cts400_filter_change_state": {"entity_type": "binary_sensor"},
+    "get_cts400_alarm_state": {"entity_type": "binary_sensor"},
+    "get_cts400_winter_mode_state": {"entity_type": "binary_sensor"},
+    "get_cts400_after_heating_state": {"entity_type": "binary_sensor"},
+    "get_cts400_deicing_state": {"entity_type": "binary_sensor"},
+    # --- switch ---
+    "get_cts400_run_state": {"entity_type": "switch"},
+    # --- numbers ---
+    "get_cts400_fan_level_setpoint": {"entity_type": "number"},
+    "get_cts400_wanted_room_temperature": {"entity_type": "number"},
+    # --- buttons ---
+    "set_cts400_reset_filter_timer": {"entity_type": "button"},
+    "set_cts400_reset_alarm": {"entity_type": "button"},
+}

--- a/custom_components/nilan/device_map.py
+++ b/custom_components/nilan/device_map.py
@@ -1882,6 +1882,8 @@ CTS400_ENTITY_MAP = {
     "get_cts400_winter_mode_state": {"entity_type": "binary_sensor"},
     "get_cts400_after_heating_state": {"entity_type": "binary_sensor"},
     "get_cts400_deicing_state": {"entity_type": "binary_sensor"},
+    # --- fan (primary control) ---
+    "get_cts400_fan": {"entity_type": "fan"},
     # --- switch ---
     "get_cts400_run_state": {"entity_type": "switch"},
     # --- numbers ---

--- a/custom_components/nilan/device_map.py
+++ b/custom_components/nilan/device_map.py
@@ -1882,6 +1882,8 @@ CTS400_ENTITY_MAP = {
     "get_cts400_winter_mode_state": {"entity_type": "binary_sensor"},
     "get_cts400_after_heating_state": {"entity_type": "binary_sensor"},
     "get_cts400_deicing_state": {"entity_type": "binary_sensor"},
+    # --- climate (FAN_ONLY thermostat) ---
+    "get_cts400_climate": {"entity_type": "climate"},
     # --- fan (primary control) ---
     "get_cts400_fan": {"entity_type": "fan"},
     # --- switch ---
@@ -1889,6 +1891,8 @@ CTS400_ENTITY_MAP = {
     # --- numbers ---
     "get_cts400_fan_level_setpoint": {"entity_type": "number"},
     "get_cts400_wanted_room_temperature": {"entity_type": "number"},
+    "get_cts400_summer_winter_threshold": {"entity_type": "number"},
+    "get_cts400_filter_interval": {"entity_type": "number"},
     # --- buttons ---
     "set_cts400_reset_filter_timer": {"entity_type": "button"},
     "set_cts400_reset_alarm": {"entity_type": "button"},

--- a/custom_components/nilan/fan.py
+++ b/custom_components/nilan/fan.py
@@ -5,12 +5,11 @@ from homeassistant.components.fan import FanEntity, FanEntityFeature
 
 from .__init__ import NilanEntity
 from .const import DOMAIN
+from .cts400_util import SPEED_COUNT, level_to_percentage, percentage_to_level
 
 # CTS400 ventilation maps Home Assistant 0-100 % onto fan levels 1-4.
 # 0 % = stop; 25/50/75/100 % = level 1/2/3/4. speed_count = 4 makes the
 # tile's increase/decrease arrows step exactly one level.
-SPEED_COUNT = 4
-
 ATTRIBUTE_TO_FAN = {
     # entity-map key (a Device method) -> translation/unique_id name
     "get_cts400_fan": "cts400_ventilation",
@@ -72,7 +71,7 @@ class NilanCTS400Fan(FanEntity, NilanEntity):
 
     async def async_set_percentage(self, percentage: int) -> None:
         """Map a percentage to fan level 1-4 (0 % stops the unit)."""
-        level = max(0, min(SPEED_COUNT, round(percentage / 25)))
+        level = percentage_to_level(percentage)
         if level == 0:
             await self._device.set_cts400_run_state(False)
             return
@@ -91,4 +90,4 @@ class NilanCTS400Fan(FanEntity, NilanEntity):
         level = await self._device.get_cts400_fan_level()
         if not level:
             level = await self._device.get_cts400_fan_level_setpoint()
-        self._attr_percentage = level * 25 if level else None
+        self._attr_percentage = level_to_percentage(level) if level else None

--- a/custom_components/nilan/fan.py
+++ b/custom_components/nilan/fan.py
@@ -1,0 +1,94 @@
+"""Platform for fan integration."""
+from __future__ import annotations
+
+from homeassistant.components.fan import FanEntity, FanEntityFeature
+
+from .__init__ import NilanEntity
+from .const import DOMAIN
+
+# CTS400 ventilation maps Home Assistant 0-100 % onto fan levels 1-4.
+# 0 % = stop; 25/50/75/100 % = level 1/2/3/4. speed_count = 4 makes the
+# tile's increase/decrease arrows step exactly one level.
+SPEED_COUNT = 4
+
+ATTRIBUTE_TO_FAN = {
+    # entity-map key (a Device method) -> translation/unique_id name
+    "get_cts400_fan": "cts400_ventilation",
+}
+
+
+async def async_setup_entry(hass, config_entry, async_add_entities):
+    """Set up the fan platform."""
+    device = hass.data[DOMAIN][config_entry.entry_id]
+    fans = []
+    for attribute in device.get_assigned("fan"):
+        if attribute in ATTRIBUTE_TO_FAN:
+            fans.append(
+                NilanCTS400Fan(device, attribute, ATTRIBUTE_TO_FAN[attribute])
+            )
+    async_add_entities(fans, update_before_add=True)
+
+
+class NilanCTS400Fan(FanEntity, NilanEntity):
+    """CTS400 ventilation fan: run/stop plus four speed levels."""
+
+    _attr_supported_features = (
+        FanEntityFeature.SET_SPEED
+        | FanEntityFeature.TURN_ON
+        | FanEntityFeature.TURN_OFF
+    )
+    _attr_speed_count = SPEED_COUNT
+
+    def __init__(self, device, attribute, name) -> None:
+        """Init the fan."""
+        super().__init__(device)
+        self._device = device
+        self._attribute = attribute
+        self._name = name
+        self._enable_turn_on_off_backwards_compatibility = False
+        self._attr_translation_key = name
+        self._attr_has_entity_name = True
+        self._attr_unique_id = name
+        self._attr_is_on = None
+        self._attr_percentage = None
+
+    @property
+    def icon(self) -> str:
+        """Pick an icon based on run state."""
+        return "mdi:fan" if self._attr_is_on else "mdi:fan-off"
+
+    async def async_turn_on(
+        self, percentage=None, preset_mode=None, **kwargs
+    ) -> None:
+        """Turn the unit on, optionally at a given speed."""
+        if percentage is not None and percentage > 0:
+            await self.async_set_percentage(percentage)
+        else:
+            await self._device.set_cts400_run_state(True)
+
+    async def async_turn_off(self, **kwargs) -> None:
+        """Stop the unit."""
+        await self._device.set_cts400_run_state(False)
+
+    async def async_set_percentage(self, percentage: int) -> None:
+        """Map a percentage to fan level 1-4 (0 % stops the unit)."""
+        level = max(0, min(SPEED_COUNT, round(percentage / 25)))
+        if level == 0:
+            await self._device.set_cts400_run_state(False)
+            return
+        await self._device.set_cts400_fan_level_setpoint(level)
+        await self._device.set_cts400_run_state(True)
+
+    async def async_update(self) -> None:
+        """Fetch run state and current speed."""
+        is_on = await self._device.get_cts400_run_state()
+        self._attr_is_on = is_on
+        if not is_on:
+            self._attr_percentage = 0
+            return
+        # The live level (input 63) lags right after a start, reading 0 for a
+        # poll or two; fall back to the setpoint so the slider doesn't snap to 0.
+        level = await self._device.get_cts400_fan_level()
+        if not level:
+            level = await self._device.get_cts400_fan_level_setpoint()
+        self._attr_percentage = level * 25 if level else None

--- a/custom_components/nilan/fan.py
+++ b/custom_components/nilan/fan.py
@@ -7,9 +7,7 @@ from .__init__ import NilanEntity
 from .const import DOMAIN
 from .cts400_util import SPEED_COUNT, level_to_percentage, percentage_to_level
 
-# CTS400 ventilation maps Home Assistant 0-100 % onto fan levels 1-4.
-# 0 % = stop; 25/50/75/100 % = level 1/2/3/4. speed_count = 4 makes the
-# tile's increase/decrease arrows step exactly one level.
+# CTS400 ventilation maps Home Assistant 0-100 % onto fan levels 1-4. 0 % = stop; 25/50/75/100 % = level 1/2/3/4. speed_count = 4 makes the tile's increase/decrease arrows step exactly one level.
 ATTRIBUTE_TO_FAN = {
     # entity-map key (a Device method) -> translation/unique_id name
     "get_cts400_fan": "cts400_ventilation",

--- a/custom_components/nilan/number.py
+++ b/custom_components/nilan/number.py
@@ -723,8 +723,9 @@ class NilanCTS602Number(NumberEntity, NilanEntity):
         self._attr_translation_key = self._name
         self._attr_has_entity_name = True
         self._attr_unique_id = self._name
-        # Redundant with the CTS400 fan platform's speed control; ship it
-        # disabled so the fan is the single ventilation control by default.
+        # NOTE: keyed on the entity name string from ATTRIBUTE_TO_NUMBERS; if
+        # that name is renamed, update this guard too. Redundant with the
+        # CTS400 fan platform's speed control, so it ships disabled by default.
         if self._name == "cts400_fan_level_setpoint":
             self._attr_entity_registry_enabled_default = False
 

--- a/custom_components/nilan/number.py
+++ b/custom_components/nilan/number.py
@@ -606,6 +606,33 @@ ATTRIBUTE_TO_NUMBERS = {
             "mdi:thermometer-lines",
         )
     ],
+    # --- CTS400 / ES1077 ---
+    "get_cts400_fan_level_setpoint": [
+        Map(
+            "cts400_fan_level_setpoint",
+            "set_cts400_fan_level_setpoint",
+            None,
+            1,
+            4,
+            1,
+            NumberMode.BOX,
+            None,
+            "mdi:fan",
+        )
+    ],
+    "get_cts400_wanted_room_temperature": [
+        Map(
+            "cts400_wanted_room_temperature",
+            "set_cts400_wanted_room_temperature",
+            None,
+            10,
+            30,
+            0.5,
+            NumberMode.BOX,
+            UnitOfTemperature.CELSIUS,
+            "mdi:thermometer",
+        )
+    ],
 }
 
 

--- a/custom_components/nilan/number.py
+++ b/custom_components/nilan/number.py
@@ -723,9 +723,7 @@ class NilanCTS602Number(NumberEntity, NilanEntity):
         self._attr_translation_key = self._name
         self._attr_has_entity_name = True
         self._attr_unique_id = self._name
-        # NOTE: keyed on the entity name string from ATTRIBUTE_TO_NUMBERS; if
-        # that name is renamed, update this guard too. Redundant with the
-        # CTS400 fan platform's speed control, so it ships disabled by default.
+        # NOTE: keyed on the entity name string from ATTRIBUTE_TO_NUMBERS; if that name is renamed, update this guard too. Redundant with the CTS400 fan platform's speed control, so it ships disabled by default.
         if self._name == "cts400_fan_level_setpoint":
             self._attr_entity_registry_enabled_default = False
 

--- a/custom_components/nilan/number.py
+++ b/custom_components/nilan/number.py
@@ -697,6 +697,10 @@ class NilanCTS602Number(NumberEntity, NilanEntity):
         self._attr_translation_key = self._name
         self._attr_has_entity_name = True
         self._attr_unique_id = self._name
+        # Redundant with the CTS400 fan platform's speed control; ship it
+        # disabled so the fan is the single ventilation control by default.
+        if self._name == "cts400_fan_level_setpoint":
+            self._attr_entity_registry_enabled_default = False
 
     async def async_set_native_value(self, value: float) -> None:
         """Update the current value."""

--- a/custom_components/nilan/number.py
+++ b/custom_components/nilan/number.py
@@ -651,7 +651,7 @@ ATTRIBUTE_TO_NUMBERS = {
             "cts400_filter_interval",
             "set_cts400_filter_interval",
             EntityCategory.CONFIG,
-            0,
+            1,
             360,
             1,
             NumberMode.BOX,

--- a/custom_components/nilan/number.py
+++ b/custom_components/nilan/number.py
@@ -633,6 +633,32 @@ ATTRIBUTE_TO_NUMBERS = {
             "mdi:thermometer",
         )
     ],
+    "get_cts400_summer_winter_threshold": [
+        Map(
+            "cts400_summer_winter_threshold",
+            "set_cts400_summer_winter_threshold",
+            EntityCategory.CONFIG,
+            5,
+            20,
+            0.5,
+            NumberMode.BOX,
+            UnitOfTemperature.CELSIUS,
+            "mdi:sun-snowflake-variant",
+        )
+    ],
+    "get_cts400_filter_interval": [
+        Map(
+            "cts400_filter_interval",
+            "set_cts400_filter_interval",
+            EntityCategory.CONFIG,
+            0,
+            360,
+            1,
+            NumberMode.BOX,
+            UnitOfTime.DAYS,
+            "mdi:air-filter",
+        )
+    ],
 }
 
 

--- a/custom_components/nilan/registers.py
+++ b/custom_components/nilan/registers.py
@@ -517,3 +517,50 @@ class CTS602HoldingRegisters:
     hps_param_cooling_allow = 6700
     hps_param_select_hw_tank = 6701
     hps_param_buffer_tank = 6702
+
+
+class CTS400InputRegisters:
+    """Register map of Nilan CTS400 / ES1077 (FC04 input registers).
+
+    Firmware 1.0. Verified live on a Comfort 250 Top (slave 30, 19200 8E1).
+    The CTS400 address space is completely different from the CTS602 above;
+    notably temperatures/humidity use one decimal (scale 0.1, divide by 10),
+    where the CTS602 uses two decimals (scale 0.01).
+    """
+
+    bypass_open = 23            # 1 = open
+    extract_air_pct = 24        # uint16 x0.1
+    supply_air_pct = 25         # uint16 x0.1
+    after_heat_pct = 26         # uint16 x0.1
+    t1_outdoor = 27             # int16 x0.1 (fresh air in)
+    t2_supply = 28              # int16 x0.1 (to rooms)
+    t3_extract = 29             # int16 x0.1 (from rooms)
+    t4_exhaust = 30             # int16 x0.1 (out)
+    humidity = 31               # uint16 x0.1
+    avg_humidity = 46           # uint16 x0.1 - reads 0 on fw 1.0; DO NOT expose
+    co2 = 47                    # ppm - option-gated (no sensor on base unit)
+    voc = 48                    # ppm - option-gated
+    filter_change = 49          # 1 = change due
+    alarm_status = 50           # 0 = no alarm
+    alarm_code_1 = 51
+    alarm_code_2 = 52
+    alarm_code_3 = 53
+    fan_level = 63              # current level 1-4 (0 when stopped)
+    mode_winter = 72            # 0 = summer, 1 = winter
+    after_heating = 74          # on/off
+    deicing = 91                # 0 = off, 1 = on
+    filter_days_remaining = 110  # days
+
+
+class CTS400HoldingRegisters:
+    """Setpoints of Nilan CTS400 / ES1077 (FC03 read / FC06 write).
+
+    Firmware 1.0. Verified live on a Comfort 250 Top.
+    """
+
+    reset_alarm = 30            # write 1
+    extra_sensor = 48           # 0 = none, 1 = VOC, 2 = CO2
+    wanted_room_temp = 37       # int16 x0.1
+    reset_filter_timer = 51     # write 1, self-clearing
+    fan_level_set = 69          # 1-4 (write inert while stopped; applies on start)
+    run_stop = 70               # 1 = run, 0 = stop  (protocol doc "1=Stop" is a typo)

--- a/custom_components/nilan/registers.py
+++ b/custom_components/nilan/registers.py
@@ -561,6 +561,8 @@ class CTS400HoldingRegisters:
     reset_alarm = 30            # write 1
     extra_sensor = 48           # 0 = none, 1 = VOC, 2 = CO2
     wanted_room_temp = 37       # int16 x0.1
+    summer_winter_threshold = 45  # int16 x0.1; season switch vs outdoor temp
+    filter_interval = 50        # days between filter changes (0-360)
     reset_filter_timer = 51     # write 1, self-clearing
     fan_level_set = 69          # 1-4 (write inert while stopped; applies on start)
     run_stop = 70               # 1 = run, 0 = stop  (protocol doc "1=Stop" is a typo)

--- a/custom_components/nilan/registers.py
+++ b/custom_components/nilan/registers.py
@@ -564,5 +564,6 @@ class CTS400HoldingRegisters:
     summer_winter_threshold = 45  # int16 x0.1; season switch vs outdoor temp
     filter_interval = 50        # days between filter changes (0-360)
     reset_filter_timer = 51     # write 1, self-clearing
+    heater_select = 53          # 0/1 = none/norm, 2 = water, 3 = electric
     fan_level_set = 69          # 1-4 (write inert while stopped; applies on start)
     run_stop = 70               # 1 = run, 0 = stop  (protocol doc "1=Stop" is a typo)

--- a/custom_components/nilan/registers.py
+++ b/custom_components/nilan/registers.py
@@ -522,10 +522,7 @@ class CTS602HoldingRegisters:
 class CTS400InputRegisters:
     """Register map of Nilan CTS400 / ES1077 (FC04 input registers).
 
-    Firmware 1.0. Verified live on a Comfort 250 Top (slave 30, 19200 8E1).
-    The CTS400 address space is completely different from the CTS602 above;
-    notably temperatures/humidity use one decimal (scale 0.1, divide by 10),
-    where the CTS602 uses two decimals (scale 0.01).
+    Firmware 1.0. Verified live on a Comfort 250 Top (slave 30, 19200 8E1). The CTS400 address space is completely different from the CTS602 above; notably temperatures/humidity use one decimal (scale 0.1, divide by 10), where the CTS602 uses two decimals (scale 0.01).
     """
 
     bypass_open = 23            # 1 = open

--- a/custom_components/nilan/sensor.py
+++ b/custom_components/nilan/sensor.py
@@ -575,6 +575,172 @@ ATTRIBUTE_TO_SENSORS = {
             True,
         )
     ],
+    # --- CTS400 / ES1077 ---
+    "get_cts400_outdoor_temperature": [
+        Map(
+            "cts400_outdoor_temperature",
+            UnitOfTemperature.CELSIUS,
+            SensorDeviceClass.TEMPERATURE,
+            SensorStateClass.MEASUREMENT,
+            None,
+            None,
+            True,
+        )
+    ],
+    "get_cts400_supply_temperature": [
+        Map(
+            "cts400_supply_temperature",
+            UnitOfTemperature.CELSIUS,
+            SensorDeviceClass.TEMPERATURE,
+            SensorStateClass.MEASUREMENT,
+            None,
+            None,
+            True,
+        )
+    ],
+    "get_cts400_extract_temperature": [
+        Map(
+            "cts400_extract_temperature",
+            UnitOfTemperature.CELSIUS,
+            SensorDeviceClass.TEMPERATURE,
+            SensorStateClass.MEASUREMENT,
+            None,
+            None,
+            True,
+        )
+    ],
+    "get_cts400_exhaust_temperature": [
+        Map(
+            "cts400_exhaust_temperature",
+            UnitOfTemperature.CELSIUS,
+            SensorDeviceClass.TEMPERATURE,
+            SensorStateClass.MEASUREMENT,
+            None,
+            None,
+            True,
+        )
+    ],
+    "get_cts400_humidity": [
+        Map(
+            "cts400_humidity",
+            PERCENTAGE,
+            SensorDeviceClass.HUMIDITY,
+            SensorStateClass.MEASUREMENT,
+            None,
+            None,
+            True,
+        )
+    ],
+    "get_cts400_extract_air_capacity": [
+        Map(
+            "cts400_extract_air_capacity",
+            PERCENTAGE,
+            None,
+            SensorStateClass.MEASUREMENT,
+            None,
+            "mdi:fan",
+            True,
+        )
+    ],
+    "get_cts400_supply_air_capacity": [
+        Map(
+            "cts400_supply_air_capacity",
+            PERCENTAGE,
+            None,
+            SensorStateClass.MEASUREMENT,
+            None,
+            "mdi:fan",
+            True,
+        )
+    ],
+    "get_cts400_after_heating_capacity": [
+        Map(
+            "cts400_after_heating_capacity",
+            PERCENTAGE,
+            None,
+            SensorStateClass.MEASUREMENT,
+            None,
+            "mdi:radiator",
+            True,
+        )
+    ],
+    "get_cts400_fan_level": [
+        Map(
+            "cts400_fan_level",
+            None,
+            None,
+            SensorStateClass.MEASUREMENT,
+            None,
+            "mdi:fan",
+            True,
+        )
+    ],
+    "get_cts400_filter_days_remaining": [
+        Map(
+            "cts400_filter_days_remaining",
+            UnitOfTime.DAYS,
+            None,
+            SensorStateClass.MEASUREMENT,
+            None,
+            "mdi:calendar-end",
+            True,
+        )
+    ],
+    "get_cts400_alarm_code_1": [
+        Map(
+            "cts400_alarm_code_1",
+            None,
+            None,
+            None,
+            EntityCategory.DIAGNOSTIC,
+            "mdi:alert-circle-outline",
+            True,
+        )
+    ],
+    "get_cts400_alarm_code_2": [
+        Map(
+            "cts400_alarm_code_2",
+            None,
+            None,
+            None,
+            EntityCategory.DIAGNOSTIC,
+            "mdi:alert-circle-outline",
+            True,
+        )
+    ],
+    "get_cts400_alarm_code_3": [
+        Map(
+            "cts400_alarm_code_3",
+            None,
+            None,
+            None,
+            EntityCategory.DIAGNOSTIC,
+            "mdi:alert-circle-outline",
+            True,
+        )
+    ],
+    "get_cts400_co2": [
+        Map(
+            "cts400_co2",
+            CONCENTRATION_PARTS_PER_MILLION,
+            SensorDeviceClass.CO2,
+            SensorStateClass.MEASUREMENT,
+            None,
+            None,
+            True,
+        )
+    ],
+    "get_cts400_voc": [
+        Map(
+            "cts400_voc",
+            CONCENTRATION_PARTS_PER_MILLION,
+            None,
+            SensorStateClass.MEASUREMENT,
+            None,
+            "mdi:air-filter",
+            True,
+        )
+    ],
 }
 
 

--- a/custom_components/nilan/strings.json
+++ b/custom_components/nilan/strings.json
@@ -1,6 +1,13 @@
 {
   "config": {
     "step": {
+      "board": {
+        "title": "Select controller board",
+        "menu_options": {
+          "cts602": "CTS602 (Comfort / Compact / VP)",
+          "cts400": "CTS400 / ES1077 (Comfort 250 Top)"
+        }
+      },
       "menu": {
         "title": "[%key:common::config_flow::menu::title%]",
         "menu_options":{
@@ -49,10 +56,18 @@
       "circulation_pump": {"name": "Circulation Pump"},
       "heater_relay_1": {"name": "Heater Relay 1"},
       "heater_relay_2": {"name": "Heater Relay 2"},
-      "heater_relay_3": {"name": "Heater Relay 3"}
+      "heater_relay_3": {"name": "Heater Relay 3"},
+      "cts400_bypass": {"name": "Bypass"},
+      "cts400_filter_change": {"name": "Filter Change"},
+      "cts400_alarm": {"name": "Alarm"},
+      "cts400_winter_mode": {"name": "Winter Mode"},
+      "cts400_after_heating": {"name": "After Heating"},
+      "cts400_deicing": {"name": "Deicing"}
     },
     "button": {
-      "sync_time": {"name": "Synchronize Time and Date"}
+      "sync_time": {"name": "Synchronize Time and Date"},
+      "cts400_reset_filter_timer": {"name": "Reset Filter Timer"},
+      "cts400_reset_alarm": {"name": "Reset Alarm"}
     },
     "climate": {
       "hvac": {
@@ -176,7 +191,9 @@
       "user_selection_1_room_temperature": {"name": "User Selection 1 Room Temperature"},
       "user_selection_2_room_temperature": {"name": "User Selection 2 Room Temperature"},
       "user_selection_1_offset_temperature": {"name": "User Selection 1 Offset Temperature"},
-      "user_selection_2_offset_temperature": {"name": "User Selection 2 Offset Temperature"}
+      "user_selection_2_offset_temperature": {"name": "User Selection 2 Offset Temperature"},
+      "cts400_fan_level_setpoint": {"name": "Fan Level"},
+      "cts400_wanted_room_temperature": {"name": "Wanted Room Temperature"}
     },
     "select": {
         "air_filter_alarm_interval": {
@@ -637,11 +654,27 @@
         "hps_output_compvolt1": {"name": "AIR/GEO Compressor Voltage"},
         "hps_alarms_active": {"name": "AIR/GEO Alarms Active"},
         "hps_water_heater_setpoint_actual": {"name": "AIR/GEO Water Heater Setpoint Actual"},
-        "hps_heating_setpoint_actual": {"name": "AIR/GEO Heating Setpoint Actual"}
+        "hps_heating_setpoint_actual": {"name": "AIR/GEO Heating Setpoint Actual"},
+      "cts400_outdoor_temperature": {"name": "Outdoor Temperature (T1)"},
+      "cts400_supply_temperature": {"name": "Supply Temperature (T2)"},
+      "cts400_extract_temperature": {"name": "Extract Temperature (T3)"},
+      "cts400_exhaust_temperature": {"name": "Exhaust Temperature (T4)"},
+      "cts400_humidity": {"name": "Humidity"},
+      "cts400_extract_air_capacity": {"name": "Extract Fan Capacity"},
+      "cts400_supply_air_capacity": {"name": "Supply Fan Capacity"},
+      "cts400_after_heating_capacity": {"name": "After Heating Capacity"},
+      "cts400_fan_level": {"name": "Fan Level"},
+      "cts400_filter_days_remaining": {"name": "Filter Days Remaining"},
+      "cts400_alarm_code_1": {"name": "Alarm Code 1"},
+      "cts400_alarm_code_2": {"name": "Alarm Code 2"},
+      "cts400_alarm_code_3": {"name": "Alarm Code 3"},
+      "cts400_co2": {"name": "CO2"},
+      "cts400_voc": {"name": "VOC"}
     },
     "switch": {
       "supply_air_after_heating": {"name": "Supply Air After Heating"},
-      "hps_main_switch": {"name": "AIR/GEO Power"}
+      "hps_main_switch": {"name": "AIR/GEO Power"},
+      "cts400_ventilation": {"name": "Ventilation"}
     },
     "water_heater": {
       "top_water_heater": {

--- a/custom_components/nilan/strings.json
+++ b/custom_components/nilan/strings.json
@@ -671,6 +671,9 @@
       "cts400_co2": {"name": "CO2"},
       "cts400_voc": {"name": "VOC"}
     },
+    "fan": {
+      "cts400_ventilation": {"name": "Ventilation"}
+    },
     "switch": {
       "supply_air_after_heating": {"name": "Supply Air After Heating"},
       "hps_main_switch": {"name": "AIR/GEO Power"},

--- a/custom_components/nilan/strings.json
+++ b/custom_components/nilan/strings.json
@@ -144,7 +144,8 @@
             "name": "Target temperature"
           }
         }
-      }
+      },
+      "cts400_hvac": {"name": "Climate"}
     },
     "number": {
       "scalding_protection_setpoint": {"name": "Scalding Protection Setpoint"},
@@ -193,7 +194,9 @@
       "user_selection_1_offset_temperature": {"name": "User Selection 1 Offset Temperature"},
       "user_selection_2_offset_temperature": {"name": "User Selection 2 Offset Temperature"},
       "cts400_fan_level_setpoint": {"name": "Fan Level"},
-      "cts400_wanted_room_temperature": {"name": "Wanted Room Temperature"}
+      "cts400_wanted_room_temperature": {"name": "Wanted Room Temperature"},
+      "cts400_summer_winter_threshold": {"name": "Summer/Winter Threshold"},
+      "cts400_filter_interval": {"name": "Filter Interval"}
     },
     "select": {
         "air_filter_alarm_interval": {

--- a/custom_components/nilan/switch.py
+++ b/custom_components/nilan/switch.py
@@ -105,6 +105,11 @@ class NilanCTS602Switch(SwitchEntity, NilanEntity):
         self._attr_translation_key = self._name
         self._attr_has_entity_name = True
         self._attr_unique_id = self._name
+        # The CTS400 fan platform is the primary ventilation control; the
+        # equivalent run/stop switch is shipped disabled to avoid two
+        # identical "Ventilation" controls. Users can enable it if preferred.
+        if self._name == "cts400_ventilation":
+            self._attr_entity_registry_enabled_default = False
 
     @property
     def icon(self) -> str | None:

--- a/custom_components/nilan/switch.py
+++ b/custom_components/nilan/switch.py
@@ -105,9 +105,11 @@ class NilanCTS602Switch(SwitchEntity, NilanEntity):
         self._attr_translation_key = self._name
         self._attr_has_entity_name = True
         self._attr_unique_id = self._name
-        # The CTS400 fan platform is the primary ventilation control; the
-        # equivalent run/stop switch is shipped disabled to avoid two
-        # identical "Ventilation" controls. Users can enable it if preferred.
+        # NOTE: keyed on the entity name string from ATTRIBUTE_TO_SWITCHES; if
+        # that name is renamed, update this guard too. The CTS400 fan platform
+        # is the primary ventilation control, so the equivalent run/stop switch
+        # is shipped disabled to avoid two identical "Ventilation" controls.
+        # Users can enable it if preferred.
         if self._name == "cts400_ventilation":
             self._attr_entity_registry_enabled_default = False
 

--- a/custom_components/nilan/switch.py
+++ b/custom_components/nilan/switch.py
@@ -105,11 +105,7 @@ class NilanCTS602Switch(SwitchEntity, NilanEntity):
         self._attr_translation_key = self._name
         self._attr_has_entity_name = True
         self._attr_unique_id = self._name
-        # NOTE: keyed on the entity name string from ATTRIBUTE_TO_SWITCHES; if
-        # that name is renamed, update this guard too. The CTS400 fan platform
-        # is the primary ventilation control, so the equivalent run/stop switch
-        # is shipped disabled to avoid two identical "Ventilation" controls.
-        # Users can enable it if preferred.
+        # NOTE: keyed on the entity name string from ATTRIBUTE_TO_SWITCHES; if that name is renamed, update this guard too. The CTS400 fan platform is the primary ventilation control, so the equivalent run/stop switch is shipped disabled to avoid two identical "Ventilation" controls. Users can enable it if preferred.
         if self._name == "cts400_ventilation":
             self._attr_entity_registry_enabled_default = False
 

--- a/custom_components/nilan/switch.py
+++ b/custom_components/nilan/switch.py
@@ -36,6 +36,17 @@ ATTRIBUTE_TO_SWITCHES = {
             None,
         )
     ],
+    "get_cts400_run_state": [
+        Map(
+            "cts400_ventilation",
+            "set_cts400_run_state",
+            None,
+            0,
+            1,
+            "mdi:fan-off",
+            "mdi:fan",
+        )
+    ],
 }
 
 

--- a/custom_components/nilan/translations/en.json
+++ b/custom_components/nilan/translations/en.json
@@ -11,6 +11,13 @@
 
         },
         "step": {
+            "board": {
+                "title": "Select Controller Board",
+                "menu_options": {
+                    "cts602": "CTS602 (Comfort / Compact / VP)",
+                    "cts400": "CTS400 / ES1077 (Comfort 250 Top)"
+                }
+            },
             "menu": {
                 "title": "Select Interface Type",
                 "menu_options": {
@@ -50,10 +57,18 @@
             "circulation_pump": {"name": "Circulation Pump"},
             "heater_relay_1": {"name": "Heater Relay 1"},
             "heater_relay_2": {"name": "Heater Relay 2"},
-            "heater_relay_3": {"name": "Heater Relay 3"}
+            "heater_relay_3": {"name": "Heater Relay 3"},
+            "cts400_bypass": {"name": "Bypass"},
+            "cts400_filter_change": {"name": "Filter Change"},
+            "cts400_alarm": {"name": "Alarm"},
+            "cts400_winter_mode": {"name": "Winter Mode"},
+            "cts400_after_heating": {"name": "After Heating"},
+            "cts400_deicing": {"name": "Deicing"}
         },
         "button": {
-          "sync_time": {"name": "Synchronize Time and Date"}
+          "sync_time": {"name": "Synchronize Time and Date"},
+          "cts400_reset_filter_timer": {"name": "Reset Filter Timer"},
+          "cts400_reset_alarm": {"name": "Reset Alarm"}
         },
         "climate": {
           "hvac": {
@@ -177,7 +192,9 @@
           "user_selection_1_room_temperature": {"name": "User Selection 1 Room Temperature"},
           "user_selection_2_room_temperature": {"name": "User Selection 2 Room Temperature"},
           "user_selection_1_offset_temperature": {"name": "User Selection 1 Offset Temperature"},
-          "user_selection_2_offset_temperature": {"name": "User Selection 2 Offset Temperature"}
+          "user_selection_2_offset_temperature": {"name": "User Selection 2 Offset Temperature"},
+          "cts400_fan_level_setpoint": {"name": "Fan Level"},
+          "cts400_wanted_room_temperature": {"name": "Wanted Room Temperature"}
         },
         "select": {
             "air_filter_alarm_interval": {
@@ -638,11 +655,27 @@
             "hps_output_compvolt1": {"name": "AIR/GEO Compressor Voltage"},
             "hps_alarms_active": {"name": "AIR/GEO Alarms Active"},
             "hps_water_heater_setpoint_actual": {"name": "AIR/GEO Water Heater Setpoint Actual"},
-            "hps_heating_setpoint_actual": {"name": "AIR/GEO Heating Setpoint Actual"}
+            "hps_heating_setpoint_actual": {"name": "AIR/GEO Heating Setpoint Actual"},
+            "cts400_outdoor_temperature": {"name": "Outdoor Temperature (T1)"},
+            "cts400_supply_temperature": {"name": "Supply Temperature (T2)"},
+            "cts400_extract_temperature": {"name": "Extract Temperature (T3)"},
+            "cts400_exhaust_temperature": {"name": "Exhaust Temperature (T4)"},
+            "cts400_humidity": {"name": "Humidity"},
+            "cts400_extract_air_capacity": {"name": "Extract Fan Capacity"},
+            "cts400_supply_air_capacity": {"name": "Supply Fan Capacity"},
+            "cts400_after_heating_capacity": {"name": "After Heating Capacity"},
+            "cts400_fan_level": {"name": "Fan Level"},
+            "cts400_filter_days_remaining": {"name": "Filter Days Remaining"},
+            "cts400_alarm_code_1": {"name": "Alarm Code 1"},
+            "cts400_alarm_code_2": {"name": "Alarm Code 2"},
+            "cts400_alarm_code_3": {"name": "Alarm Code 3"},
+            "cts400_co2": {"name": "CO2"},
+            "cts400_voc": {"name": "VOC"}
         },
         "switch": {
           "supply_air_after_heating": {"name": "Supply Air After Heating"},
-          "hps_main_switch": {"name": "AIR/GEO Power"}
+          "hps_main_switch": {"name": "AIR/GEO Power"},
+          "cts400_ventilation": {"name": "Ventilation"}
         },
         "water_heater": {
           "top_water_heater": {

--- a/custom_components/nilan/translations/en.json
+++ b/custom_components/nilan/translations/en.json
@@ -672,6 +672,9 @@
             "cts400_co2": {"name": "CO2"},
             "cts400_voc": {"name": "VOC"}
         },
+        "fan": {
+          "cts400_ventilation": {"name": "Ventilation"}
+        },
         "switch": {
           "supply_air_after_heating": {"name": "Supply Air After Heating"},
           "hps_main_switch": {"name": "AIR/GEO Power"},

--- a/custom_components/nilan/translations/en.json
+++ b/custom_components/nilan/translations/en.json
@@ -145,7 +145,8 @@
                 "name": "Target temperature"
               }
             }
-          }
+          },
+          "cts400_hvac": {"name": "Climate"}
         },
         "number": {
           "scalding_protection_setpoint": {"name": "Scalding Protection Setpoint"},
@@ -194,7 +195,9 @@
           "user_selection_1_offset_temperature": {"name": "User Selection 1 Offset Temperature"},
           "user_selection_2_offset_temperature": {"name": "User Selection 2 Offset Temperature"},
           "cts400_fan_level_setpoint": {"name": "Fan Level"},
-          "cts400_wanted_room_temperature": {"name": "Wanted Room Temperature"}
+          "cts400_wanted_room_temperature": {"name": "Wanted Room Temperature"},
+          "cts400_summer_winter_threshold": {"name": "Summer/Winter Threshold"},
+          "cts400_filter_interval": {"name": "Filter Interval"}
         },
         "select": {
             "air_filter_alarm_interval": {

--- a/requirements_test.txt
+++ b/requirements_test.txt
@@ -1,0 +1,2 @@
+pytest
+PyYAML

--- a/requirements_test.txt
+++ b/requirements_test.txt
@@ -1,2 +1,1 @@
 pytest
-PyYAML

--- a/tests/test_cts400_behaviour.py
+++ b/tests/test_cts400_behaviour.py
@@ -1,0 +1,45 @@
+"""CTS400 behavioural unit tests for the pure helpers (no hardware, no HA)."""
+from custom_components.nilan.cts400_util import (
+    decode_signed16,
+    level_to_percentage,
+    percentage_to_level,
+)
+
+
+def test_percentage_to_level_slider_multiples():
+    # The HA tile emits multiples of 25 for a 4-speed fan.
+    assert percentage_to_level(0) == 0
+    assert percentage_to_level(25) == 1
+    assert percentage_to_level(50) == 2
+    assert percentage_to_level(75) == 3
+    assert percentage_to_level(100) == 4
+
+
+def test_percentage_to_level_half_boundaries_round_up():
+    # Round-half-up (not banker's rounding): .5 boundaries go to the higher
+    # level predictably.
+    assert percentage_to_level(12.5) == 1
+    assert percentage_to_level(37.5) == 2
+    assert percentage_to_level(62.5) == 3
+    assert percentage_to_level(87.5) == 4
+
+
+def test_percentage_to_level_clamped():
+    assert percentage_to_level(-10) == 0
+    assert percentage_to_level(200) == 4
+
+
+def test_level_to_percentage_roundtrip():
+    for level in (1, 2, 3, 4):
+        assert level_to_percentage(level) == level * 25
+        assert percentage_to_level(level_to_percentage(level)) == level
+
+
+def test_decode_signed16():
+    assert decode_signed16(0) == 0
+    assert decode_signed16(100) == 100        # 10.0 C raw
+    assert decode_signed16(0x7FFF) == 32767
+    assert decode_signed16(0x8000) == -32768
+    assert decode_signed16(0xFFFF) == -1
+    # A real negative outdoor temperature: -5.0 C is raw -50 = 0xFFCE.
+    assert decode_signed16(0xFFCE) == -50

--- a/tests/test_cts400_behaviour.py
+++ b/tests/test_cts400_behaviour.py
@@ -16,8 +16,7 @@ def test_percentage_to_level_slider_multiples():
 
 
 def test_percentage_to_level_half_boundaries_round_up():
-    # Round-half-up (not banker's rounding): .5 boundaries go to the higher
-    # level predictably.
+    # Round-half-up (not banker's rounding): .5 boundaries go to the higher level predictably.
     assert percentage_to_level(12.5) == 1
     assert percentage_to_level(37.5) == 2
     assert percentage_to_level(62.5) == 3

--- a/tests/test_cts400_consistency.py
+++ b/tests/test_cts400_consistency.py
@@ -31,7 +31,7 @@ def _referenced_cts400_names() -> set[str]:
     """
     names: set[str] = set()
     for pyfile in ("sensor.py", "binary_sensor.py", "switch.py",
-                   "number.py", "button.py", "fan.py"):
+                   "number.py", "button.py", "fan.py", "climate.py"):
         path = ROOT / pyfile
         if not path.exists():
             continue

--- a/tests/test_cts400_consistency.py
+++ b/tests/test_cts400_consistency.py
@@ -22,6 +22,28 @@ def _cts400_entity_map_keys() -> set[str]:
     raise AssertionError("CTS400_ENTITY_MAP not found")
 
 
+def _referenced_cts400_names() -> set[str]:
+    """All cts400_* entity names referenced by the platform modules.
+
+    These are the string literals used as a Map's name / translation_key
+    (e.g. "cts400_outdoor_temperature", "cts400_ventilation"). Entity-map
+    keys in device_map.py are get_/set_ prefixed and so do not match.
+    """
+    names: set[str] = set()
+    for pyfile in ("sensor.py", "binary_sensor.py", "switch.py",
+                   "number.py", "button.py", "fan.py"):
+        path = ROOT / pyfile
+        if not path.exists():
+            continue
+        tree = ast.parse(path.read_text(encoding="utf-8"))
+        for node in ast.walk(tree):
+            if (isinstance(node, ast.Constant)
+                    and isinstance(node.value, str)
+                    and node.value.startswith("cts400_")):
+                names.add(node.value)
+    return names
+
+
 def test_entity_map_keys_are_device_methods():
     methods = _methods("device.py")
     for key in _cts400_entity_map_keys():
@@ -43,4 +65,13 @@ def test_cts400_entity_names_have_translations():
 
     en_names, str_names = cts400_names(en), cts400_names(strings)
     assert en_names, "no cts400_* names in en.json"
+    # the two translation files must agree with each other ...
     assert en_names == str_names, en_names ^ str_names
+    # ... and every name actually referenced by a platform module must have a
+    # translation in BOTH files (catches a name missing from either file).
+    referenced = _referenced_cts400_names()
+    assert referenced, "no cts400_* names referenced by platform modules"
+    missing_en = referenced - en_names
+    assert not missing_en, f"missing from en.json: {sorted(missing_en)}"
+    missing_str = referenced - str_names
+    assert not missing_str, f"missing from strings.json: {sorted(missing_str)}"

--- a/tests/test_cts400_consistency.py
+++ b/tests/test_cts400_consistency.py
@@ -1,0 +1,46 @@
+"""CTS400 entity-map <-> Device methods <-> translations consistency."""
+import ast
+import json
+import pathlib
+
+ROOT = pathlib.Path(__file__).resolve().parents[1] / "custom_components" / "nilan"
+
+
+def _methods(pyfile: str) -> set[str]:
+    tree = ast.parse((ROOT / pyfile).read_text(encoding="utf-8"))
+    return {n.name for n in ast.walk(tree)
+            if isinstance(n, (ast.FunctionDef, ast.AsyncFunctionDef))}
+
+
+def _cts400_entity_map_keys() -> set[str]:
+    tree = ast.parse((ROOT / "device_map.py").read_text(encoding="utf-8"))
+    for node in ast.walk(tree):
+        if (isinstance(node, ast.Assign)
+                and any(getattr(t, "id", "") == "CTS400_ENTITY_MAP"
+                        for t in node.targets)):
+            return {k.value for k in node.value.keys}
+    raise AssertionError("CTS400_ENTITY_MAP not found")
+
+
+def test_entity_map_keys_are_device_methods():
+    methods = _methods("device.py")
+    for key in _cts400_entity_map_keys():
+        assert key in methods, f"{key} has no Device method"
+
+
+def test_cts400_entity_names_have_translations():
+    en = json.loads((ROOT / "translations" / "en.json").read_text("utf-8"))
+    strings = json.loads((ROOT / "strings.json").read_text("utf-8"))
+
+    # collect every cts400_* leaf name across both files' entity sections
+    def cts400_names(blob):
+        out = set()
+        for section in blob.get("entity", {}).values():
+            for key in section:
+                if key.startswith("cts400_"):
+                    out.add(key)
+        return out
+
+    en_names, str_names = cts400_names(en), cts400_names(strings)
+    assert en_names, "no cts400_* names in en.json"
+    assert en_names == str_names, en_names ^ str_names

--- a/tests/test_cts400_consistency.py
+++ b/tests/test_cts400_consistency.py
@@ -25,9 +25,7 @@ def _cts400_entity_map_keys() -> set[str]:
 def _referenced_cts400_names() -> set[str]:
     """All cts400_* entity names referenced by the platform modules.
 
-    These are the string literals used as a Map's name / translation_key
-    (e.g. "cts400_outdoor_temperature", "cts400_ventilation"). Entity-map
-    keys in device_map.py are get_/set_ prefixed and so do not match.
+    These are the string literals used as a Map's name / translation_key (e.g. "cts400_outdoor_temperature", "cts400_ventilation"). Entity-map keys in device_map.py are get_/set_ prefixed and so do not match.
     """
     names: set[str] = set()
     for pyfile in ("sensor.py", "binary_sensor.py", "switch.py",

--- a/tests/test_cts400_registers.py
+++ b/tests/test_cts400_registers.py
@@ -38,10 +38,7 @@ def test_no_duplicate_addresses_within_a_space():
 
 
 def test_shared_numbers_are_cross_space_only():
-    # These addresses legitimately exist in BOTH spaces with different
-    # meanings (input vs holding): 30 (T4 / reset alarm), 48 (VOC / extra
-    # sensor), 51 (alarm code 1 / reset filter timer), 53 (alarm code 3 /
-    # heater select).
+    # These addresses legitimately exist in BOTH spaces with different meanings (input vs holding): 30 (T4 / reset alarm), 48 (VOC / extra sensor), 51 (alarm code 1 / reset filter timer), 53 (alarm code 3 / heater select).
     for addr in (30, 48, 51, 53):
         assert addr in DOC_INPUT.values()
         assert addr in DOC_HOLDING.values()

--- a/tests/test_cts400_registers.py
+++ b/tests/test_cts400_registers.py
@@ -14,8 +14,9 @@ DOC_INPUT = {
     "after_heating": 74, "deicing": 91, "filter_days_remaining": 110,
 }
 DOC_HOLDING = {
-    "reset_alarm": 30, "wanted_room_temp": 37, "extra_sensor": 48,
-    "reset_filter_timer": 51, "fan_level_set": 69, "run_stop": 70,
+    "reset_alarm": 30, "wanted_room_temp": 37, "summer_winter_threshold": 45,
+    "extra_sensor": 48, "filter_interval": 50, "reset_filter_timer": 51,
+    "heater_select": 53, "fan_level_set": 69, "run_stop": 70,
 }
 
 
@@ -37,7 +38,10 @@ def test_no_duplicate_addresses_within_a_space():
 
 
 def test_shared_numbers_are_cross_space_only():
-    # 30/48/51 legitimately exist in BOTH spaces with different meanings.
-    for addr in (30, 48, 51):
+    # These addresses legitimately exist in BOTH spaces with different
+    # meanings (input vs holding): 30 (T4 / reset alarm), 48 (VOC / extra
+    # sensor), 51 (alarm code 1 / reset filter timer), 53 (alarm code 3 /
+    # heater select).
+    for addr in (30, 48, 51, 53):
         assert addr in DOC_INPUT.values()
         assert addr in DOC_HOLDING.values()

--- a/tests/test_cts400_registers.py
+++ b/tests/test_cts400_registers.py
@@ -1,0 +1,43 @@
+"""CTS400 register-map parity (no hardware, no HA import)."""
+from custom_components.nilan.registers import (
+    CTS400HoldingRegisters as H,
+    CTS400InputRegisters as I,
+)
+
+# ES1077/CTS400 protocol document, section 4 (verified on a live unit).
+DOC_INPUT = {
+    "bypass_open": 23, "extract_air_pct": 24, "supply_air_pct": 25,
+    "after_heat_pct": 26, "t1_outdoor": 27, "t2_supply": 28, "t3_extract": 29,
+    "t4_exhaust": 30, "humidity": 31, "avg_humidity": 46, "co2": 47, "voc": 48,
+    "filter_change": 49, "alarm_status": 50, "alarm_code_1": 51,
+    "alarm_code_2": 52, "alarm_code_3": 53, "fan_level": 63, "mode_winter": 72,
+    "after_heating": 74, "deicing": 91, "filter_days_remaining": 110,
+}
+DOC_HOLDING = {
+    "reset_alarm": 30, "wanted_room_temp": 37, "extra_sensor": 48,
+    "reset_filter_timer": 51, "fan_level_set": 69, "run_stop": 70,
+}
+
+
+def test_input_registers_match_protocol_doc():
+    for name, addr in DOC_INPUT.items():
+        assert getattr(I, name) == addr, name
+
+
+def test_holding_registers_match_protocol_doc():
+    for name, addr in DOC_HOLDING.items():
+        assert getattr(H, name) == addr, name
+
+
+def test_no_duplicate_addresses_within_a_space():
+    for cls in (I, H):
+        addrs = [v for k, v in vars(cls).items() if not k.startswith("_")
+                 and isinstance(v, int)]
+        assert len(addrs) == len(set(addrs)), f"duplicate in {cls.__name__}"
+
+
+def test_shared_numbers_are_cross_space_only():
+    # 30/48/51 legitimately exist in BOTH spaces with different meanings.
+    for addr in (30, 48, 51):
+        assert addr in DOC_INPUT.values()
+        assert addr in DOC_HOLDING.values()


### PR DESCRIPTION
## Why

Adds support for the Nilan CTS400 / ES1077 controller (Comfort 250 Top) alongside the existing CTS602 integration. The CTS400 uses a **different Modbus register space**, cannot be auto-detected (it has no CTS602 `control_type` register at holding 1000), and only supports function codes FC03/FC04/FC06. It therefore can't be added as a small CTS602 "device key" and is wired as a distinct board family.

This is **ready for review**, opened from a fork, and refs discussion #165. It is **additive only** - no CTS602 behavior changes.

## Provenance and verification

- Verified live on a Nilan Comfort 250 Top (ES1077 / CTS400 controller, firmware 1.0): Modbus RTU, slave 30, 19200 8E1, over a Waveshare RS485 TO ETH (B) bridge (already in this repo's tested-hardware list).
- The base register map is proven by a working Home Assistant native `modbus:` package (26 entities) that has been running in production on this unit; a sanitized copy can be shared via discussion #165.
- The regulation setpoints were added from a controlled live experiment (each register changed in isolation with HA as the sole reader, every value restored) - see the per-entity notes below.
- This directly answers the open Q&A in #165 ("Setup Nilan Comfort 250 via Waveshare RS485 Hat"), where a Comfort 250 owner gets an invalid response from this integration while the native Modbus integration responds on slave 30 - the exact CTS400-vs-CTS602 mismatch this PR addresses.
- Not a migration: it does not replace anyone's native `modbus:` package, it adds first-class integration support.

## Approach

A `board_type` seam selects the register/entity space at setup:

- **registers.py** - `CTS400InputRegisters` / `CTS400HoldingRegisters`.
- **device.py** - `board_type` on `Device` plus `_setup_cts400()`, which builds the entity map, reads holding 53 to learn whether an after-heater is fitted, and gates CO2/VOC on the extra sensor (holding 48). Reads use FC03/FC04; writes use FC06 (`write_register`, single value).
- **config_flow.py** - a board-picker step and board-aware validation (CTS400 has no `control_type`, so it probes run/stop at holding 70).
- **__init__.py** - reads `board_type` from the entry, threads it into `Device`, and registers the `fan` platform.
- **device_map.py / sensor / binary_sensor / switch / number / button / strings.json / translations** - CTS400 entity metadata and names (keys prefixed `cts400_` to avoid unique_id collisions when both boards run in one HA instance).

## Entities

Telemetry: temperatures T1-T4 (signed, x0.1), humidity / supply / extract / after-heat percentages (x0.1), CO2 / VOC (raw ppm, only when the extra sensor is fitted), bypass, de-icing, filter status, alarm status plus raw codes, and days-to-filter-change.

Controls:

- **Fan** (`fan.cts400_ventilation`) - the primary speed control. Maps HA 0-100 % onto stop / level 1-4 (fan level holding 69 + run/stop holding 70); `speed_count = 4` so the tile arrows step exactly one level. Falls back to the setpoint while the live level (input 63) lags for a poll after a start.
- **Climate** (`climate.cts400_hvac`, FAN_ONLY / OFF) - optional thermostat card, **disabled by default** because it overlaps the fan. It only advertises `TARGET_TEMPERATURE` when an after-heater is present (holding 53 = 2 water / 3 electric); on a base unit (holding 53 = 1, verified live) the setpoint is inert.
- **Run/stop switch** and **fan-level number** - shipped with `entity_registry_enabled_default = False` to avoid two identical "Ventilation" controls now that the fan is primary.
- **Wanted room temperature** (holding 37) - live-verified write plus exact read-back; the controller itself rejects out-of-range writes, so the software clamp is belt-and-suspenders.
- **Summer/winter threshold** (holding 45, CONFIG number 5.0-20.0 C) - live-verified to move winter mode (input 72) against outdoor temperature; entry is fast, exit is strongly hysteretic (documented in the setter).
- **Filter interval** (holding 50, CONFIG number 1-360 days; 0 = always due) - live-verified to update days-remaining (input 110) immediately.

## Tests

First automated tests for the integration, all hardware-free and HA-import-free (`pytest -q tests/`):

- `tests/test_cts400_registers.py` - CTS400 registers match the protocol doc section 4, with no duplicate addresses within a register space.
- `tests/test_cts400_consistency.py` - every `CTS400_ENTITY_MAP` key resolves to a `Device` method, and every `cts400_*` entity name has a translation in both `strings.json` and `en.json` (checked in both directions, including the platform modules).
- `conftest.py` + `requirements_test.txt` (pytest + PyYAML). No CI workflow added; the repo's CI is hassfest + HACS-validate.

## Notes for reviewers

- **Scale differs by board:** CTS400 temps/humidity/air% use scale 0.1 (divide by 10); CTS602 uses 0.01 (divide by 100). This is the main reason a shared entity map isn't feasible.
- **Protocol-doc corrections** verified live: run/stop is holding 70 with `1=run / 0=stop` (the doc's "1=Stop" is a typo), fan level is holding 69, filter reset is holding 51.
- **The alarm code to name mapping is intentionally left UNCONFIRMED** - raw codes are exposed as diagnostic sensors; no names are invented.
- **Deliberately left out:** de-icing thresholds (holding 39/40), pending a winter run; bypass stays read-only (verified season-gated, not driven by the temperature setpoint).
- The "average humidity" register (input 46) reads a constant 0 on this firmware and is not exposed.

refs #165
