### PR TITLE
fix: cast hw_version to str for HA device registry compatibility

### DIFF
--- a/custom_components/nilan/__init__.py
+++ b/custom_components/nilan/__init__.py
@@ -103,6 +103,6 @@ class NilanEntity(Entity):
             "manufacturer": "Nilan",
             "model": self._device.get_device_type,
             "sw_version": self._device.get_device_sw_version,
-            "hw_version": self._device.get_device_hw_version,
+            "hw_version": str(self._device.get_device_hw_version),
             "suggested_area": "Boiler Room",
         }


### PR DESCRIPTION
## Problem

`NilanEntity.device_info` passes `hw_version` as `int`, but the Home Assistant device registry requires `str`. This causes 82 warnings per HA startup on a CTS602 system:

```
ValueError: hw_version must be a string (got <class 'int'>)
```

Reported in: #224

## Root Cause

In `device.py`, `get_controller_hardware_version()` returns `int`:
```python
def get_controller_hardware_version(self) -> int:
    return self._device_hw_ver
```

In `__init__.py`, the value is passed directly to the device registry without casting:
```python
"hw_version": self._device.get_device_hw_version,  # int → TypeError
```

Compare `sw_version` which already uses `get_device_sw_version -> str` and works correctly.

## Fix

One-line change in `custom_components/nilan/__init__.py`:

```python
"hw_version": str(self._device.get_device_hw_version),
```

## Impact

- Fixes 82 warnings per HA restart (one per registered Nilan entity)
- Prevents breakage in a future HA release where this may be enforced as an error
- No functional change to integration behaviour

## Tested on

- Home Assistant 2026.6.3
- Nilan CTS602 (82 entities)
- Warnings: 82 → 0 after restart