### PR TITLE
Fix pymodbus TCP transaction_id desync after Nilan reconnect

### DIFF
--- a/custom_components/nilan/device.py
+++ b/custom_components/nilan/device.py
@@ -2,16 +2,162 @@
 
 from __future__ import annotations
 
+import asyncio
 import datetime
 import logging
 
-from homeassistant.components.modbus import modbus
+from pymodbus.client import AsyncModbusSerialClient, AsyncModbusTcpClient
+from pymodbus.exceptions import ModbusException
+
 from homeassistant.core import HomeAssistant
 
 from .device_map import CTS602_DEVICE_TYPES, CTS602_ENTITY_MAP
 from .registers import CTS602HoldingRegisters, CTS602InputRegisters
 
 _LOGGER = logging.getLogger(__name__)
+
+
+class _NilanModbusClient:
+    """Pymodbus wrapper with TCP reconnect-desync recovery.
+
+    Nilan devices reset their Modbus TCP transaction_id counter on every
+    compressor stop / TCP disconnect.  pymodbus 3.11.x keeps incrementing its
+    own counter across reconnects, so responses get permanently discarded
+    ("request ask for transaction_id=54205 but got id=57, Skipping.").
+
+    Fix: detect N consecutive None returns and force-close + recreate the
+    client.  A brand-new AsyncModbusTcpClient starts its transaction counter
+    at 0, which re-syncs with the Nilan device.
+    """
+
+    _FAILURE_THRESHOLD = 5
+
+    def __init__(self, com_type: str, host: str | None, port) -> None:
+        self._com_type = com_type
+        self._host = host
+        self._port = port
+        self._client: AsyncModbusTcpClient | AsyncModbusSerialClient | None = None
+        self._lock: asyncio.Lock = asyncio.Lock()
+        self._consecutive_failures: int = 0
+        self._reconnect_scheduled: bool = False
+        self.event_connected: asyncio.Event = asyncio.Event()
+
+    def _create_client(self) -> AsyncModbusTcpClient | AsyncModbusSerialClient:
+        if self._com_type == "tcp":
+            return AsyncModbusTcpClient(
+                self._host,
+                port=int(self._port),
+                timeout=1,
+                reconnect_delay=0.1,
+                reconnect_delay_max=300.0,
+                on_reconnect_callback=self._on_reconnect,
+            )
+        return AsyncModbusSerialClient(
+            self._port,
+            stopbits=1,
+            bytesize=8,
+            parity="E",
+            baudrate=19200,
+            timeout=1,
+        )
+
+    def _on_reconnect(self) -> None:
+        """Called by pymodbus after an automatic TCP reconnect.
+
+        Resets the failure counter so a forced reconnect is not triggered
+        on top of the auto-reconnect that pymodbus already performed.
+        """
+        _LOGGER.warning(
+            "Nilan: TCP auto-reconnected — failure counter reset"
+        )
+        self._consecutive_failures = 0
+
+    async def async_setup(self) -> bool:
+        """Create and connect the Modbus client."""
+        self._client = self._create_client()
+        connected = await self._client.connect()
+        if connected:
+            self.event_connected.set()
+            return True
+        self._client.close()
+        self._client = None
+        return False
+
+    async def async_close(self) -> None:
+        """Disconnect and discard the Modbus client."""
+        self.event_connected.clear()
+        if self._client is not None:
+            self._client.close()
+            self._client = None
+
+    async def async_pb_call(
+        self,
+        unit_id: int,
+        register: int,
+        value,
+        use_call: str,
+    ):
+        """Execute a Modbus read or write, tracking failures for desync recovery."""
+        if self._client is None:
+            return None
+        async with self._lock:
+            try:
+                if use_call == "input":
+                    result = await self._client.read_input_registers(
+                        register, count=value, device_id=unit_id
+                    )
+                elif use_call == "holding":
+                    result = await self._client.read_holding_registers(
+                        register, count=value, device_id=unit_id
+                    )
+                elif use_call == "write_registers":
+                    await self._client.write_registers(
+                        register, value, device_id=unit_id
+                    )
+                    return None
+                else:
+                    return None
+                if result is None or result.isError():
+                    return self._on_failure()
+                self._consecutive_failures = 0
+                return result
+            except ModbusException as exc:
+                _LOGGER.debug("Modbus exception during %s: %s", use_call, exc)
+                return self._on_failure()
+
+    def _on_failure(self):
+        self._consecutive_failures += 1
+        if (
+            self._com_type == "tcp"
+            and self._consecutive_failures >= self._FAILURE_THRESHOLD
+            and not self._reconnect_scheduled
+        ):
+            self._reconnect_scheduled = True
+            asyncio.ensure_future(self._force_reconnect())
+        return None
+
+    async def _force_reconnect(self) -> None:
+        """Close and recreate the TCP client to reset the transaction ID counter."""
+        _LOGGER.warning(
+            "Nilan: %d consecutive Modbus failures — forcing reconnect to fix transaction ID desync",
+            self._consecutive_failures,
+        )
+        async with self._lock:
+            try:
+                if self._client is not None:
+                    self._client.close()
+            except Exception:  # pylint: disable=broad-except
+                pass
+            await asyncio.sleep(2.0)
+            self._consecutive_failures = 0
+            self._client = self._create_client()
+            connected = await self._client.connect()
+            if connected:
+                self.event_connected.set()
+                _LOGGER.warning("Nilan: forced reconnect successful")
+            else:
+                _LOGGER.error("Nilan: forced reconnect failed")
+            self._reconnect_scheduled = False
 
 
 class Device:
@@ -36,20 +182,7 @@ class Device:
         self._host_port = host_port
         self._unit_id = int(unit_id)
         self._com_type = com_type
-        self._client_config = {
-            "name": self._device_name,
-            "type": self._com_type,
-            "method": "rtu",
-            "delay": 0,
-            "port": self._host_port,
-            "timeout": 1,
-            "host": self._host_ip,
-            "parity": "E",
-            "baudrate": 19200,
-            "bytesize": 8,
-            "stopbits": 1,
-        }
-        self._modbus = modbus.ModbusHub(self.hass, self._client_config)
+        self._modbus = _NilanModbusClient(self._com_type, self._host_ip, self._host_port)
         self._attributes = {}
         self._air_geo_type = 0
 

--- a/custom_components/nilan/manifest.json
+++ b/custom_components/nilan/manifest.json
@@ -3,7 +3,7 @@
   "name": "Nilan",
   "codeowners": ["@veista"],
   "config_flow": true,
-  "dependencies": ["modbus"],
+  "dependencies": [],
   "documentation": "https://github.com/veista/nilan",
   "iot_class": "local_polling",
   "issue_tracker": "https://github.com/veista/nilan/issues",


### PR DESCRIPTION
## Problem

Since pymodbus 3.11.x, the Nilan integration can enter a permanent communication failure state after the Nilan device briefly drops its TCP connection — which happens on **every compressor stop**. Once in this state, all entities freeze at their last known value. An integration reload does **not** help; only a full `docker restart home-assistant` recovers it.

The failure is visible in the logs as a flood of:

```
ERROR ... request ask for transaction_id=54205 but got id=57, Skipping.
ERROR ... request ask for transaction_id=54205 but got id=58, Skipping.
ERROR ... request ask for transaction_id=54205 but got id=59, Skipping.
```

In the affected installation this caused daily desync episodes lasting between 30 minutes and 18 hours, with the compressor entity frozen and cooling completely unmonitorable/uncontrollable.

## Root Cause

Modbus TCP frames carry a **transaction identifier (TID)** that the server must echo back in its response. pymodbus uses this to match responses to in-flight requests.

The problem is a mismatch in how the two sides manage this counter:

| | What happens on TCP reconnect |
|---|---|
| **pymodbus 3.11.x** | Keeps incrementing its internal counter — e.g. picks up at TID 54 205 |
| **Nilan CTS602** | Resets its own TID counter to a low value (e.g. 57) |

After reconnect, pymodbus sends a request stamped with TID 54 205. The Nilan responds with TID 57 (its freshly reset counter). pymodbus looks for a pending request with TID 57, finds none, and discards the response with _"Skipping"_. The request eventually times out and returns `None`. Every subsequent request shifts both counters by one, keeping them permanently ~54 148 apart. The integration is effectively dead until pymodbus is destroyed and recreated.

The previous code used **HA's `ModbusHub`** abstraction, which gives no access to the underlying pymodbus client or its reconnect parameters. There was no way to influence this behavior from the integration.

## Fix

### 1. Replace `ModbusHub` with a direct `AsyncModbusTcpClient`

A new internal class `_NilanModbusClient` wraps `AsyncModbusTcpClient` / `AsyncModbusSerialClient` directly, exposing the same `async_pb_call` API that every getter and setter in `device.py` already calls — so none of those 200+ call sites need to change.

### 2. Add reconnect parameters

```python
AsyncModbusTcpClient(
    host,
    port=port,
    timeout=1,
    reconnect_delay=0.1,        # reconnect quickly after TCP drop
    reconnect_delay_max=300.0,  # but back off if repeated failures
    on_reconnect_callback=self._on_reconnect,
)
```

### 3. Detect desync via consecutive-failure counting

Every `async_pb_call` that returns `None` or an error increments a counter. Five consecutive failures (≈ one polling cycle) trigger `_force_reconnect()`.

### 4. Force-reconnect resets the TID counter

`_force_reconnect()` closes the existing client and creates a **brand-new `AsyncModbusTcpClient` instance**. A new instance starts its TID counter at 0 — which re-syncs with the Nilan device that also started fresh. This is the only reliable fix: pymodbus's auto-reconnect does *not* reset the counter; only instantiating a new client does.

During the 2-second reconnect window the asyncio lock is held, so any concurrent reads queue up cleanly and resume with the fresh client.

### 5. Remove `"modbus"` from `manifest.json` dependencies

HA's built-in modbus integration is no longer used, so the load-order dependency is removed.

## Affected Users

Anyone using the Nilan integration with a heat-pump model (CTS602 AIR/GEO/CompactP) where the Nilan controller drops the TCP connection on compressor state changes. The symptom is entities freezing periodically, recoverable only by restarting Home Assistant.