### PR TITLE
Correct pymodbus requirement syntax

### DIFF
--- a/custom_components/nilan/manifest.json
+++ b/custom_components/nilan/manifest.json
@@ -7,6 +7,6 @@
   "documentation": "https://github.com/veista/nilan",
   "iot_class": "local_polling",
   "issue_tracker": "https://github.com/veista/nilan/issues",
-  "requirements": ["pymodbus>=3.11.1,<3.12"],
+  "requirements": ["pymodbus>=3.11.1,"],
   "version": "1.2.27"
 }


### PR DESCRIPTION
Fix requirements format for pymodbus in manifest.json.