### PR TITLE
Fix entity mapping for hw_type 11 (VP 18comp), incl. missing water heater entities

### DIFF
--- a/custom_components/nilan/device_map.py
+++ b/custom_components/nilan/device_map.py
@@ -95,7 +95,7 @@ CTS602_ENTITY_MAP = {
         "entity_type": "sensor",
         "min_bus_version": 1,
         "min_hps_bus_version": 1,
-        "supported_devices": (None,),
+        "supported_devices": (11,),
     },
     "get_t3_exhaust_temperature": {
         "entity_type": "sensor",
@@ -106,6 +106,7 @@ CTS602_ENTITY_MAP = {
             3,
             13,
             31,
+            11,
         ),
     },
     "get_t4_outlet": {
@@ -124,6 +125,7 @@ CTS602_ENTITY_MAP = {
             35,
             36,
             44,
+            11,
         ),
     },
     "get_t5_condenser_temperature": {
@@ -216,7 +218,7 @@ CTS602_ENTITY_MAP = {
         "entity_type": "sensor",
         "min_bus_version": 1,
         "min_hps_bus_version": 1,
-        "supported_devices": (None,),
+        "supported_devices": (11,),
     },
     "get_t10_external_temperature": {
         "entity_type": "sensor",
@@ -309,7 +311,7 @@ CTS602_ENTITY_MAP = {
         "entity_type": "sensor",
         "min_bus_version": 1,
         "min_hps_bus_version": 1,
-        "supported_devices": (None,),
+        "supported_devices": (11,),
     },
     "get_humidity": {
         "entity_type": "sensor",
@@ -414,7 +416,7 @@ CTS602_ENTITY_MAP = {
         "entity_type": "sensor",
         "min_bus_version": 1,
         "min_hps_bus_version": 1,
-        "supported_devices": (None,),
+        "supported_devices": (11,),
     },
     "get_exchanger_efficiency": {
         "entity_type": "sensor",
@@ -549,13 +551,14 @@ CTS602_ENTITY_MAP = {
             35,
             36,
             44,
+            11,
         ),
     },
     "get_after_heating_element_capacity": {
         "entity_type": "sensor",
         "min_bus_version": 11,
         "min_hps_bus_version": 1,
-        "supported_devices": (None,),
+        "supported_devices": (11,),
     },
     "get_co2_present": {
         "entity_type": "config",
@@ -917,6 +920,7 @@ CTS602_ENTITY_MAP = {
             30,
             31,
             44,
+            11,
         ),
     },
     "get_max_supply_air_winter_setpoint": {
@@ -937,6 +941,7 @@ CTS602_ENTITY_MAP = {
             30,
             31,
             44,
+            11,
         ),
     },
     "get_summer_state_change_setpoint": {
@@ -1096,6 +1101,7 @@ CTS602_ENTITY_MAP = {
             38,
             42,
             44,
+            11,
         ),
     },
     "get_compressor_priority": {
@@ -1463,6 +1469,7 @@ CTS602_ENTITY_MAP = {
             35,
             36,
             44,
+            11,
         ),
     },
     "get_low_room_temperature_setpoint": {
@@ -1495,7 +1502,7 @@ CTS602_ENTITY_MAP = {
         "entity_type": "switch",
         "min_bus_version": 19,
         "min_hps_bus_version": 1,
-        "supported_devices": (None,),
+        "supported_devices": (11,),
     },
     "get_min_supply_step": {
         "entity_type": "select",
@@ -1594,6 +1601,7 @@ CTS602_ENTITY_MAP = {
             38,
             42,
             44,
+            11,
         ),
     },
     "get_defrost_start_setpoint": {
@@ -1649,6 +1657,7 @@ CTS602_ENTITY_MAP = {
             33,
             35,
             44,
+            11,
         ),
     },
     "get_maximum_outlet_defrost_time": {
@@ -1660,6 +1669,7 @@ CTS602_ENTITY_MAP = {
             33,
             35,
             44,
+            11,
         ),
     },
     "get_minimum_defrost_time": {

--- a/custom_components/nilan/translations/de.json
+++ b/custom_components/nilan/translations/de.json
@@ -398,7 +398,7 @@
           "supply_air_temperature_t2": {"name": "Zulufttemperatur (T2)"},
           "return_air_temperature_t3": {"name": "Rücklufttemperatur (T3)"},
           "waste_air_temperature_t4": {"name": "Ablufttemperatur (T4)"},
-          "condenser_temperature_t5": {"name": "Kondensattemperatur (T5)"},
+          "condenser_temperature_t5": {"name": "Kondensatortemperatur (T5)"},
           "waste_air_temperature_t6": {"name": "Ablufttemperatur (T6)"},
           "supply_air_temperature_t7": {"name": "Zulufttemperatur (T7)"},
           "fresh_air_intake_temperature_t8": {"name": "Frischlufteinlasstemperatur (T8)"},


### PR DESCRIPTION
## Summary

This PR fixes the entity mapping for device type **11 (`VP 18comp`)**. On this unit a number of registers return valid values, but no entities are created because `supported_devices` either omits `11` or is set to `(None,)`.

**All changes are limited to device type 11 — no other device type is touched.**

Verified against a real VP 18 M2 (`Control.Type` = 11, `Bus.Version` = 23, controller software 3.6.64) by reading all 293 registers documented in the CTS602 / HMI350T Modbus specification v23, with the integration disabled so no second Modbus client could interfere with the readings.

## 1. Water heater entities never appear on VP 18comp

`water_heater.py` requires **all six** capabilities before creating either entity:

```python
if all(attribute in device.get_attributes for attribute in water_heater_capabilities):
```

Five of the six list device 11 — one does not:

| capability | `supported_devices` |
| --- | --- |
| `get_control_state` | `("all",)` |
| `get_electric_water_heater_setpoint` | `(10, 11, 12, 19, 20, 21, …)` |
| `get_t11_electric_water_heater_temperature` | `(10, 11, 12, 19, 20, 21, …)` |
| `get_electric_water_heater_state` | `(10, 11, 12, 19, 20, 21, …)` |
| **`get_compressor_water_heater_setpoint`** | **`(10, 12, 19, 20, 21, 28, …)` — 11 missing** |
| `get_t12_compressor_water_heater_temperature` | `(10, 11, 12, 19, 20, 21, …)` |

Because of the `all()` gate, this single omission means **neither** water heater entity is ever created on a VP 18comp — the hot water setpoints are only readable from the physical HMI panel.

Measured on the unit: register `1700` = 3500 (35.0 °C, electric setpoint) and register `1701` = 5300 (53.0 °C, compressor setpoint) — both match the values shown on the panel. After adding `11`, both entities appear and report `electric` / `heat_pump`.

## 2. `supported_devices: (None,)` can never match

Seven entries use `(None,)`:

```
get_t2_inlet_temperature, get_t9_heater_temperature, get_t16_sacrificial_anode_temperature,
get_room_master_temperature, get_after_heating_element_capacity, get_hps_water_heater_setpoint,
get_supply_air_after_heating
```

The selection logic in `device.py` is:

```python
hw_type in value["supported_devices"] or "all" in value["supported_devices"]
```

Against `(None,)` both operands are always `False`, for **every** device type — so these entries can never produce an entity on any hardware.

This PR sets them to `(11,)` where the register was verified to return data on a VP 18comp. **`get_hps_water_heater_setpoint` is deliberately left untouched**, since it belongs to the AIR/GEO branch (`air_geo_type != 0`) and cannot be verified here.

❓ Could you advise which device types were originally intended for the remaining entries? That information isn't derivable from the outside, and I'd rather not guess on hardware I can't measure.

## 3. Registers that return data but have no entity on VP 18comp

Measured values in brackets:

- **`get_bypass_flap_state`** — register 3000 (`1` = open). Notable one: the bypass damper state was previously invisible, so summer bypass operation could only be inferred indirectly from the heat exchanger efficiency dropping.
- `get_t4_outlet` (26.45 °C), `get_t2_inlet_temperature` (24.70 °C), `get_room_master_temperature` (26.33 °C), `get_t10_external_temperature`, `get_exchanger_efficiency`
- `get_max_supply_air_summer_setpoint` / `get_max_supply_air_winter_setpoint` (35.0 °C)
- defrost parameters: `get_time_between_defrost` (45 min), `get_maximum_compressor_defrost_time`, `get_maximum_outlet_defrost_time`

Entries for hardware that is **optional on this model but not fitted on the test unit** are included as well, so owners who do have it get the entities — they can simply be disabled in Home Assistant: `get_t3_exhaust_temperature`, `get_t9_heater_temperature`, `get_t16_sacrificial_anode_temperature`, `get_after_heating_element_capacity`, `get_supply_air_after_heating`, `get_supply_heater_delay`, `get_co2_high_limit_setpoint`. CO₂ presence is already detected at runtime via register 3003, so no assumption is made there.

**Deliberately not included:** `get_t8_outdoor_temperature`. On this unit register 208 returns bit-identical values to T1 (both 20.63 °C while the outdoor weather station reported 33.3 °C — this installation draws its intake air through a ground heat exchanger). A second entity duplicating T1 would be misleading. Central heating registers are left out as well, since it could not be established whether VP 18comp supports a heating circuit at all.

## 4. German translation: condenser ≠ condensate

`de.json` renders `Condenser Temperature (T5)` as *"Kondensattemperatur"* — that is the **condensate** (the water), not the **condenser** (the component). Corrected to *"Kondensatortemperatur"*. The English string is correct and unchanged.

---

### Separate note — not part of this PR

`en.json` names T6 `waste_air_temperature_t6`. According to the official Nilan installation manual (M24 VP 18 M2, page 8, *"Temperature sensor overview"*) T6 is the **evaporator**; waste air is **T4**.

Measured evidence: during a compressor run T6 dropped to **10.26 °C** while extract air (T10) was at **25.9 °C** — extract air cannot be 15 K colder than the room it comes from.

Renaming the key would change the displayed name for every existing user, so it is left out here deliberately. Happy to open a separate PR if you'd like that changed.
